### PR TITLE
Replace \ with / in default_editor for windows

### DIFF
--- a/src/edit.rs
+++ b/src/edit.rs
@@ -29,7 +29,7 @@ fn default_editor() -> String {
 }
 #[cfg(target_os = "windows")]
 fn default_editor() -> String {
-    "C:\\Windows\\System32\\notepad.exe".to_owned()
+    "C:/Windows/System32/notepad.exe".to_owned()
 }
 
 pub fn open_editor(file_path: &Path) -> bool {


### PR DESCRIPTION
This is in regard to the minor issue mentioned in #548 
When using a bash terminal on windows there are issues with the escape character `\` which results in `notepad.exe` not being located properly.
A normal / will work just fine in a bash, cmd or powershell as tested in the screenshots below. 
![image](https://user-images.githubusercontent.com/48212402/102602456-dcdb0700-4121-11eb-8782-f9716a723280.png)
![image](https://user-images.githubusercontent.com/48212402/102602478-e2d0e800-4121-11eb-8614-5d60e2fd9b03.png)
![image](https://user-images.githubusercontent.com/48212402/102602504-e9f7f600-4121-11eb-8cef-0e90903a21d7.png)


@federico-terzi, currently i am not able to test this change in the context of espanso. If you have a small "how to build and run for dummys" i'll be happy to do so.


