### PR TITLE
chore: run gh action version update checks with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 99
+    commit_message:
+      prefix: "chore"
+      include_scope: false


### PR DESCRIPTION
We could include this dependabot action to automatically check on a weekly basis whether there are any version updates available for the GitHub actions we are using.

This could also be configured for Cargo:
- https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#package-ecosystem