### PR TITLE
Clarify "Found duplicate 'name'" error

### DIFF
--- a/Compilation.md
+++ b/Compilation.md
@@ -9,7 +9,7 @@ These are the basic tools required to build espanso:
 * A recent Rust compiler. You can install it following these instructions: https://www.rust-lang.org/tools/install
 * A C/C++ compiler. There are multiple of them depending on the platform, but espanso officially supports the following:
   * On Windows, you should use the MSVC compiler. The easiest way to install it is by downloading Visual Studio and checking "Desktop development with C++" in the installer: https://visualstudio.microsoft.com/
-  * On macOS, you should use the official build tools that come with Xcode. If you don't want to install Xcode, you should be able to download only the build tools by executing `xcode-select —install` and following the instructions.
+  * On macOS, you should use the official build tools that come with Xcode. If you don't want to install Xcode, you should be able to download only the build tools by executing `xcode-select —-install` and following the instructions.
   * On Linux, you should use the default C/C++ compiler (it's usually GCC). On Ubuntu/Debian systems, you can install them with `sudo apt install build-essential`
 
 * Espanso heavily relies on [cargo make](https://github.com/sagiegurari/cargo-make) for the various packaging

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -760,7 +760,7 @@ impl fmt::Display for ConfigLoadError {
             ConfigLoadError::InvalidYAML(path, e) => write!(f, "Error parsing YAML file '{}', invalid syntax: {}", path.to_str().unwrap_or_default(), e),
             ConfigLoadError::InvalidConfigDirectory =>  write!(f, "Invalid config directory"),
             ConfigLoadError::InvalidParameter(path) =>  write!(f, "Invalid parameter in '{}', use of reserved parameters in used defined configs is not permitted", path.to_str().unwrap_or_default()),
-            ConfigLoadError::NameDuplicate(path) =>  write!(f, "Found duplicate 'name' in '{}', please use different names", path.to_str().unwrap_or_default()),
+            ConfigLoadError::NameDuplicate(path) =>  write!(f, "Found duplicate filename, please use different names for your config files."),
             ConfigLoadError::UnableToCreateDefaultConfig =>  write!(f, "Could not generate default config file"),
         }
   }


### PR DESCRIPTION
After migrating from v0.7.3 using the compatibility mode, I had this folder structure (for some not relevant reason):

```
~/Library/Preferences/espanso $ exa --tree
├── config
│  └── default.yml # <= duplicate name
├── match
│  ├── packages
│  └── base.yml
├── user
└── default.yml    # <=duplicate name
```

I _think_ this resulted in the below error message. Is that so?

In any case, the message left me guessing which `name` is duplicated, and _where_ it is:

> [ERROR] unable to load legacy config
> 
> Caused by:
>     Found duplicate 'name' in '~/Library/Preferences/espanso/match/packages/…unrelated…/_manifest.yml', please use different names

Since that unrelated package contained quite a number of triggers with local variables, I thought at first that maybe _those names_ can't be duplicated, and renamed them. However, checking the `config.rs` code made me suspect the filenames as the problem source.

Is that so, and would in that case this rephrasing help?