### PR TITLE
feat(ci): add macOS codesign step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -167,6 +167,20 @@ jobs:
         run: cargo make create-bundle --profile release
         env:
           MACOSX_DEPLOYMENT_TARGET: "10.13"
+      - name: Codesign executable
+        env: 
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
+        run: |
+          echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain 
+          security default-keychain -s buildespanso.keychain
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain
+          security import certificate.p12 -k buildespanso.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain
+          /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" target/mac/Espanso.app -v
       - name: Create ZIP archive
         run: |
           ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-Intel.zip
@@ -204,17 +218,18 @@ jobs:
         run: cargo make create-bundle --profile release --env BUILD_ARCH=aarch64-apple-darwin
       - name: Codesign executable
         env: 
-          MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
-          MACOS_CERTIFICATE_PWD: ${{ secrets.MACOS_CERTIFICATE_PWD }}
-          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.MACOS_CI_KEYCHAIN_PWD }}
+          MACOS_CERTIFICATE: ${{ secrets.PROD_MACOS_CERTIFICATE }}
+          MACOS_CERTIFICATE_PWD: ${{ secrets.PROD_MACOS_CERTIFICATE_PWD }}
+          MACOS_CERTIFICATE_NAME: ${{ secrets.PROD_MACOS_CERTIFICATE_NAME }}
+          MACOS_CI_KEYCHAIN_PWD: ${{ secrets.PROD_MACOS_CI_KEYCHAIN_PWD }}
         run: |
           echo $MACOS_CERTIFICATE | base64 --decode > certificate.p12
-          security create-keychain -p $MACOS_CI_KEYCHAIN_PWD buildespanso.keychain 
+          security create-keychain -p "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain 
           security default-keychain -s buildespanso.keychain
-          security unlock-keychain -p $MACOS_CI_KEYCHAIN_PWD buildespanso.keychain
-          security import certificate.p12 -k buildespanso.keychain -P $MACOS_CERTIFICATE_PWD -T /usr/bin/codesign
-          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k $MACOS_CI_KEYCHAIN_PWD buildespanso.keychain
-          /usr/bin/codesign --force -s "Espanso CI Self-Signed" target/mac/Espanso.app -v
+          security unlock-keychain -p "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain
+          security import certificate.p12 -k buildespanso.keychain -P "$MACOS_CERTIFICATE_PWD" -T /usr/bin/codesign
+          security set-key-partition-list -S apple-tool:,apple:,codesign: -s -k "$MACOS_CI_KEYCHAIN_PWD" buildespanso.keychain
+          /usr/bin/codesign --force -s "$MACOS_CERTIFICATE_NAME" target/mac/Espanso.app -v
       - name: Create ZIP archive
         run: |
           ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-M1.zip


### PR DESCRIPTION
Add codesign step to macOS releases, following the tips from this great article: https://localazy.com/blog/how-to-automatically-sign-macos-apps-using-github-actions