### PR TITLE
Update sctk version (Fix #1057)

### DIFF
--- a/espanso-detect/Cargo.toml
+++ b/espanso-detect/Cargo.toml
@@ -24,7 +24,7 @@ widestring = "0.4.3"
 [target.'cfg(target_os="linux")'.dependencies]
 libc = "0.2.85"
 scopeguard = "1.1.0"
-sctk = { package = "smithay-client-toolkit", version = "0.14.0", optional = true }
+sctk = { package = "smithay-client-toolkit", version = "0.15.4", optional = true }
 
 [build-dependencies]
 cc = "1.0.73"


### PR DESCRIPTION
This update fixes the bug where espanso is not working on KDE Wayland (Issue #1057) by updating smithay-client-toolkit. Nothing else needs to be changed.