### PR TITLE
feat(core): enable alt-code emulation by default on Windows

### DIFF
--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -300,7 +300,13 @@ impl Config for ResolvedConfig {
   }
 
   fn emulate_alt_codes(&self) -> bool {
-    self.parsed.emulate_alt_codes.unwrap_or(false)
+    self.parsed.emulate_alt_codes.unwrap_or_else(|| {
+      if cfg!(target_os = "windows") {
+        true
+      } else {
+        false
+      }
+    })
   }
 
   fn post_form_delay(&self) -> usize {


### PR DESCRIPTION
This PR enables alt-code emulation by default on Windows. For more information, see https://github.com/espanso/espanso/issues/988