### PR TITLE
chore: refactor CI deployment pipelines

### DIFF
--- a/.github/workflows/dev-release.yml
+++ b/.github/workflows/dev-release.yml
@@ -1,0 +1,186 @@
+# Huge thanks to Alacritty, as their configuration served as a starting point for this one!
+# See: https://github.com/alacritty/alacritty
+
+name: Dev Release
+
+on:
+  push:
+    branches:
+      - dev
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  CARGO_TERM_COLOR: always
+
+jobs:
+  extract-version:
+    name: extract-version
+    runs-on: ubuntu-latest
+    outputs:
+      espanso_version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Extract version"
+        id: "version"
+        run: |
+          ESPANSO_VERSION=$(grep '^version' espanso/Cargo.toml | awk -F '"' '{ print $2 }')
+          echo version: $ESPANSO_VERSION
+          echo "::set-output name=version::v$ESPANSO_VERSION"
+
+  windows:
+    needs: ["extract-version"]
+    runs-on: windows-latest
+
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Install rust-script and cargo-make
+        run: |
+          cargo install rust-script --version "0.7.0"
+          cargo install --force cargo-make --version 0.34.0
+      - name: Test
+        run: cargo make test-binary --profile release
+      - name: Build resources
+        run: cargo make build-windows-resources --profile release
+      - name: Build installer
+        run: cargo make build-windows-installer --profile release --skip-tasks build-windows-resources
+      - name: Build portable mode archive 
+        run: cargo make build-windows-portable --profile release --skip-tasks build-windows-resources
+      - name: Create portable mode archive
+        shell: powershell
+        run: |
+          Rename-Item target/windows/portable espanso-portable
+          Compress-Archive target/windows/espanso-portable target/windows/Espanso-Win-Portable-x86_64.zip
+      - name: Calculate hashes
+        shell: powershell
+        run: |
+          Get-FileHash target/windows/Espanso-Win-Portable-x86_64.zip -Algorithm SHA256 | select-object -ExpandProperty Hash > target/windows/Espanso-Win-Portable-x86_64.zip.sha256.txt
+          Get-FileHash target/windows/installer/Espanso-Win-Installer-x86_64.exe -Algorithm SHA256 | select-object -ExpandProperty Hash > target/windows/installer/Espanso-Win-Installer-x86_64.exe.sha256.txt
+      - uses: actions/upload-artifact@v2
+        name: "Upload artifacts"
+        with:
+          name: Windows Artifacts
+          path: |
+            target/windows/installer/Espanso-Win-Installer-x86_64.exe
+            target/windows/Espanso-Win-Portable-x86_64.zip
+            target/windows/installer/Espanso-Win-Installer-x86_64.exe.sha256.txt
+            target/windows/Espanso-Win-Portable-x86_64.zip.sha256.txt
+  
+  linux-x11:
+    needs: ["extract-version"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Build docker image
+        run: |
+          sudo docker build -t espanso-ubuntu . -f .github/scripts/ubuntu/Dockerfile
+      - name: Build AppImage
+        run: |
+          sudo docker run --rm -v "$(pwd):/shared" espanso-ubuntu espanso/.github/scripts/ubuntu/build_appimage.sh
+      - uses: actions/upload-artifact@v2
+        name: "Upload artifacts"
+        with:
+          name: Linux X11 Artifacts
+          path: |
+            Espanso-X11.AppImage
+            Espanso-X11.AppImage.sha256.txt
+  
+  linux-deb:
+    needs: ["extract-version"]
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Build docker image
+        run: |
+          sudo docker build -t espanso-ubuntu . -f .github/scripts/ubuntu/Dockerfile
+      - name: Build Deb packages
+        run: |
+          sudo docker run --rm -v "$(pwd):/shared" espanso-ubuntu espanso/.github/scripts/ubuntu/build_deb.sh
+      - uses: actions/upload-artifact@v2
+        name: "Upload artifacts"
+        with:
+          name: Ubuntu-Debian Artifacts
+          path: |
+            espanso-debian-x11-amd64.deb
+            espanso-debian-wayland-amd64.deb
+
+
+  macos-intel:
+    needs: ["extract-version"]
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Install rust-script and cargo-make
+        run: |
+          cargo install rust-script --version "0.7.0"
+          cargo install --force cargo-make --version 0.34.0
+      - name: Test
+        run: cargo make test-binary --profile release
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+      - name: Build
+        run: cargo make create-bundle --profile release
+        env:
+          MACOSX_DEPLOYMENT_TARGET: "10.13"
+      - name: Create ZIP archive
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-Intel.zip
+      - name: Calculate hashes
+        run: |
+          shasum -a 256 Espanso-Mac-Intel.zip > Espanso-Mac-Intel.zip.sha256.txt
+      - uses: actions/upload-artifact@v2
+        name: "Upload artifacts"
+        with:
+          name: Mac Intel Artifacts
+          path: |
+            Espanso-Mac-Intel.zip
+            Espanso-Mac-Intel.zip.sha256.txt
+  
+  macos-m1:
+    needs: ["extract-version"]
+    runs-on: macos-11
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Print target version
+        run: |
+          echo Using version ${{ needs.extract-version.outputs.espanso_version }}
+      - name: Install rust target
+        run: rustup update && rustup target add aarch64-apple-darwin
+      - name: Install rust-script and cargo-make
+        run: |
+          cargo install rust-script --version "0.7.0"
+          cargo install --force cargo-make --version 0.34.0
+      - name: Build
+        run: cargo make create-bundle --profile release --env BUILD_ARCH=aarch64-apple-darwin
+      - name: Create ZIP archive
+        run: |
+          ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-M1.zip
+      - name: Calculate hashes
+        run: |
+          shasum -a 256 Espanso-Mac-M1.zip > Espanso-Mac-M1.zip.sha256.txt
+      - uses: actions/upload-artifact@v2
+        name: "Upload artifacts"
+        with:
+          name: Mac M1 Artifacts
+          path: |
+            Espanso-Mac-M1.zip
+            Espanso-Mac-M1.zip.sha256.txt

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -7,8 +7,6 @@ on:
   push:
     branches:
       - master
-      # TODO: roll this once testing is done
-      - chore/refactor-deployment-pipelines
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/prod-release.yml
+++ b/.github/workflows/prod-release.yml
@@ -1,13 +1,14 @@
 # Huge thanks to Alacritty, as their configuration served as a starting point for this one!
 # See: https://github.com/alacritty/alacritty
 
-name: Release
+name: Prod Release
 
 on:
   push:
     branches:
       - master
-      - dev
+      # TODO: roll this once testing is done
+      - chore/refactor-deployment-pipelines
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -31,6 +32,7 @@ jobs:
   create-release:
     name: create-release
     needs: ["extract-version"]
+    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -49,6 +51,7 @@ jobs:
   windows:
     needs: ["extract-version", "create-release"]
     runs-on: windows-latest
+    environment: production
 
     defaults:
       run:
@@ -110,6 +113,7 @@ jobs:
   linux-x11:
     needs: ["extract-version", "create-release"]
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - uses: actions/checkout@v2
@@ -137,6 +141,7 @@ jobs:
   linux-deb:
     needs: ["extract-version", "create-release"]
     runs-on: ubuntu-latest
+    environment: production
 
     steps:
       - uses: actions/checkout@v2
@@ -165,6 +170,7 @@ jobs:
   macos-intel:
     needs: ["extract-version", "create-release"]
     runs-on: macos-11
+    environment: production
 
     steps:
       - uses: actions/checkout@v2
@@ -235,6 +241,7 @@ jobs:
   macos-m1:
     needs: ["extract-version", "create-release"]
     runs-on: macos-11
+    environment: production
 
     steps:
       - uses: actions/checkout@v2
@@ -301,6 +308,7 @@ jobs:
   macos-publish-homebrew:
     needs: ["extract-version", "create-release", "macos-m1", "macos-intel"]
     runs-on: macos-11
+    environment: production
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
This PR refactors the release CI pipelines to make it easier for multiple maintainers to collaborate on the project, without sacrificing security.

In particular, for each commit in the `dev` branch:
- We build Espanso for all targets
- We upload the binaries as a GitHub artifact in the CI run

This should make it easier to try the most up-to-date espanso version.

On the other hand, merges in the `master` branch will trigger the `Prod Release` pipeline, which will do all the above + code sign all the executables and create a new release on GitHub. This CI run will need to be manually approved, so that we minimize the risk of new contributors messing up with the signing keys.