### PR TITLE
chore: :rotating_light: more `clippy` pedantic lints

### DIFF
--- a/espanso-clipboard/src/win32/mod.rs
+++ b/espanso-clipboard/src/win32/mod.rs
@@ -48,7 +48,7 @@ impl Clipboard for Win32Clipboard {
     }
   }
 
-  fn set_text(&self, text: &str, _: &ClipboardOperationOptions) -> anyhow::Result<()> {
+  fn set_text(&self, text: &str, _: &ClipboardOperationOptions) -> Result<()> {
     let string = U16CString::from_str(text)?;
     let native_result = unsafe { ffi::clipboard_set_text(string.as_ptr()) };
     if native_result > 0 {

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -447,7 +447,7 @@ impl ResolvedConfig {
 
     if config.use_standard_includes.is_none() || config.use_standard_includes.unwrap() {
       for include in STANDARD_INCLUDES {
-        includes.insert(include.to_string());
+        includes.insert((*include).to_string());
       }
     }
 

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -446,21 +446,21 @@ impl ResolvedConfig {
     let mut includes = HashSet::new();
 
     if config.use_standard_includes.is_none() || config.use_standard_includes.unwrap() {
-      STANDARD_INCLUDES.iter().for_each(|include| {
+      for include in STANDARD_INCLUDES {
         includes.insert(include.to_string());
-      });
+      }
     }
 
     if let Some(yaml_includes) = config.includes.as_ref() {
-      yaml_includes.iter().for_each(|include| {
+      for include in yaml_includes {
         includes.insert(include.to_string());
-      });
+      }
     };
 
     if let Some(extra_includes) = config.extra_includes.as_ref() {
-      extra_includes.iter().for_each(|include| {
+      for include in extra_includes {
         includes.insert(include.to_string());
-      });
+      }
     };
 
     includes
@@ -470,15 +470,15 @@ impl ResolvedConfig {
     let mut excludes = HashSet::new();
 
     if let Some(yaml_excludes) = config.excludes.as_ref() {
-      yaml_excludes.iter().for_each(|exclude| {
+      for exclude in yaml_excludes {
         excludes.insert(exclude.to_string());
-      });
+      }
     }
 
     if let Some(extra_excludes) = config.extra_excludes.as_ref() {
-      extra_excludes.iter().for_each(|exclude| {
+      for exclude in extra_excludes {
         excludes.insert(exclude.to_string());
-      });
+      }
     }
 
     excludes

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -740,9 +740,9 @@ mod tests {
       let parent_file = config_dir.join("parent.yml");
       std::fs::write(
         &parent_file,
-        r#"
+        r"
       excludes: ['../**/another.yml']
-      "#,
+      ",
       )
       .unwrap();
 

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -940,7 +940,7 @@ mod tests {
     };
 
     assert!(test_filter_is_match(
-      &format!("filter_os: {}", current),
+      &format!("filter_os: {current}"),
       &AppProperties {
         title: Some("Google Mail"),
         class: Some("Chrome"),
@@ -949,7 +949,7 @@ mod tests {
     ));
 
     assert!(!test_filter_is_match(
-      &format!("filter_os: {}", another),
+      &format!("filter_os: {another}"),
       &AppProperties {
         title: Some("Google Mail"),
         class: Some("Chrome"),

--- a/espanso-config/src/legacy/config.rs
+++ b/espanso-config/src/legacy/config.rs
@@ -837,11 +837,11 @@ mod tests {
   #[test]
   fn test_user_defined_config_does_not_have_reserved_fields() {
     let working_config_file = create_tmp_file(
-      r###"
+      r"
 
         backend: Clipboard
 
-        "###,
+        ",
     );
     let config = LegacyConfig::load_config(working_config_file.path());
     assert!(config.unwrap().validate_user_defined_config());
@@ -850,12 +850,12 @@ mod tests {
   #[test]
   fn test_user_defined_config_has_reserved_fields_config_caching_interval() {
     let working_config_file = create_tmp_file(
-      r###"
+      r"
 
         # This should not happen in an app-specific config
         config_caching_interval: 100
 
-        "###,
+        ",
     );
     let config = LegacyConfig::load_config(working_config_file.path());
     assert!(!config.unwrap().validate_user_defined_config());
@@ -864,12 +864,12 @@ mod tests {
   #[test]
   fn test_user_defined_config_has_reserved_fields_toggle_key() {
     let working_config_file = create_tmp_file(
-      r###"
+      r"
 
         # This should not happen in an app-specific config
         toggle_key: CTRL
 
-        "###,
+        ",
     );
     let config = LegacyConfig::load_config(working_config_file.path());
     assert!(!config.unwrap().validate_user_defined_config());
@@ -878,12 +878,12 @@ mod tests {
   #[test]
   fn test_user_defined_config_has_reserved_fields_toggle_interval() {
     let working_config_file = create_tmp_file(
-      r###"
+      r"
 
         # This should not happen in an app-specific config
         toggle_interval: 1000
 
-        "###,
+        ",
     );
     let config = LegacyConfig::load_config(working_config_file.path());
     assert!(!config.unwrap().validate_user_defined_config());
@@ -892,12 +892,12 @@ mod tests {
   #[test]
   fn test_user_defined_config_has_reserved_fields_backspace_limit() {
     let working_config_file = create_tmp_file(
-      r###"
+      r"
 
         # This should not happen in an app-specific config
         backspace_limit: 10
 
-        "###,
+        ",
     );
     let config = LegacyConfig::load_config(working_config_file.path());
     assert!(!config.unwrap().validate_user_defined_config());
@@ -1010,9 +1010,9 @@ mod tests {
     let user_defined_path = create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r"
         config_caching_interval: 10000
-        "###,
+        ",
     );
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path());
     assert!(config_set.is_err());
@@ -1029,9 +1029,9 @@ mod tests {
     let user_defined_path = create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r"
         backend: Clipboard
-        "###,
+        ",
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path());
@@ -1049,17 +1049,17 @@ mod tests {
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r"
         name: specific1
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r"
         name: specific1
-        "###,
+        ",
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path());
@@ -1073,25 +1073,25 @@ mod tests {
   #[test]
   fn test_user_defined_config_set_merge_with_parent_matches() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         matches:
             - trigger: ":lol"
               replace: "LOL"
             - trigger: ":yess"
               replace: "Bob"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific1.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: "hello"
               replace: "newstring"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1115,25 +1115,25 @@ mod tests {
   #[test]
   fn test_user_defined_config_set_merge_with_parent_matches_child_priority() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         matches:
             - trigger: ":lol"
               replace: "LOL"
             - trigger: ":yess"
               replace: "Bob"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: ":lol"
               replace: "newstring"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1153,19 +1153,19 @@ mod tests {
   #[test]
   fn test_user_defined_config_set_exclude_merge_with_parent_matches() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         matches:
             - trigger: ":lol"
               replace: "LOL"
             - trigger: ":yess"
               replace: "Bob"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r#"
         name: specific1
 
         exclude_default_entries: true
@@ -1173,7 +1173,7 @@ mod tests {
         matches:
             - trigger: "hello"
               replace: "newstring"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1189,19 +1189,19 @@ mod tests {
   #[test]
   fn test_only_yaml_files_are_loaded_from_config() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
             matches:
                 - trigger: ":lol"
                   replace: "LOL"
                 - trigger: ":yess"
                   replace: "Bob"
-            "###,
+            "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.zzz",
-      r###"
+      r#"
         name: specific1
 
         exclude_default_entries: true
@@ -1209,7 +1209,7 @@ mod tests {
         matches:
             - trigger: "hello"
               replace: "newstring"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1219,19 +1219,19 @@ mod tests {
   #[test]
   fn test_hidden_files_are_ignored() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
             matches:
                 - trigger: ":lol"
                   replace: "LOL"
                 - trigger: ":yess"
                   replace: "Bob"
-            "###,
+            "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       ".specific.yml",
-      r###"
+      r#"
         name: specific1
 
         exclude_default_entries: true
@@ -1239,7 +1239,7 @@ mod tests {
         matches:
             - trigger: "hello"
               replace: "newstring"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1253,17 +1253,17 @@ mod tests {
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r"
         name: specific1
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r"
         name: specific2
-        "###,
+        ",
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1273,23 +1273,23 @@ mod tests {
   #[test]
   fn test_config_set_default_parent_works_correctly() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         parent: default
 
         matches:
             - trigger: "hello"
               replace: "world"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1310,21 +1310,21 @@ mod tests {
   #[test]
   fn test_config_set_no_parent_should_not_merge() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         matches:
             - trigger: "hello"
               replace: "world"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1349,36 +1349,36 @@ mod tests {
   #[test]
   fn test_config_set_default_nested_parent_works_correctly() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         name: custom1
         parent: default
 
         matches:
             - trigger: "hello"
               replace: "world"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r#"
         parent: custom1
 
         matches:
             - trigger: "super"
               replace: "mario"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1404,23 +1404,23 @@ mod tests {
   #[test]
   fn test_config_set_parent_merge_children_priority_should_be_higher() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         parent: default
 
         matches:
             - trigger: "hasta"
               replace: "world"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1436,24 +1436,24 @@ mod tests {
   #[test]
   fn test_config_set_package_configs_default_merge() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_package_file(
       package_dir.path(),
       "package1",
       "package.yml",
-      r###"
+      r#"
         parent: default
 
         matches:
             - trigger: "harry"
               replace: "potter"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1474,24 +1474,24 @@ mod tests {
   #[test]
   fn test_config_set_package_configs_lower_priority_than_user() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_package_file(
       package_dir.path(),
       "package1",
       "package.yml",
-      r###"
+      r#"
         parent: default
 
         matches:
             - trigger: "hasta"
               replace: "potter"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1510,22 +1510,22 @@ mod tests {
   #[test]
   fn test_config_set_package_configs_without_merge() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_package_file(
       package_dir.path(),
       "package1",
       "package.yml",
-      r###"
+      r#"
         matches:
             - trigger: "harry"
               replace: "potter"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1545,37 +1545,37 @@ mod tests {
   #[test]
   fn test_config_set_package_configs_multiple_files() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: hasta
               replace: Hasta la vista
-        "###,
+        ",
     );
 
     create_package_file(
       package_dir.path(),
       "package1",
       "package.yml",
-      r###"
+      r#"
         name: package1
 
         matches:
             - trigger: "harry"
               replace: "potter"
-        "###,
+        "#,
     );
 
     create_package_file(
       package_dir.path(),
       "package1",
       "addon.yml",
-      r###"
+      r#"
         parent: package1
 
         matches:
             - trigger: "ron"
               replace: "weasley"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1614,25 +1614,25 @@ mod tests {
   #[test]
   fn test_has_conflict_no_conflict() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: ac
               replace: Hasta la vista
             - trigger: bc
               replace: Jon
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: "hello"
               replace: "world"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1645,7 +1645,7 @@ mod tests {
   #[test]
   fn test_has_conflict_conflict_in_default() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: ac
               replace: Hasta la vista
@@ -1653,19 +1653,19 @@ mod tests {
               replace: Jon
             - trigger: acb
               replace: Error
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: "hello"
               replace: "world"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1678,25 +1678,25 @@ mod tests {
   #[test]
   fn test_has_conflict_conflict_in_specific_and_default() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: ac
               replace: Hasta la vista
             - trigger: bc
               replace: Jon
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: "bcd"
               replace: "Conflict"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1709,36 +1709,36 @@ mod tests {
   #[test]
   fn test_has_conflict_no_conflict_in_specific_and_specific() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r"
         matches:
             - trigger: ac
               replace: Hasta la vista
             - trigger: bc
               replace: Jon
-        "###,
+        ",
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
         name: specific1
 
         matches:
             - trigger: "bad"
               replace: "Conflict"
-        "###,
+        "#,
     );
     create_user_config_file(
       data_dir.path(),
       "specific2.yml",
-      r###"
+      r#"
         name: specific2
 
         matches:
             - trigger: "badass"
               replace: "Conflict"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1751,25 +1751,25 @@ mod tests {
   #[test]
   fn test_config_set_specific_inherits_default_global_vars() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         global_vars:
             - name: testvar
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
          global_vars:
             - name: specificvar
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1789,26 +1789,26 @@ mod tests {
   #[test]
   fn test_config_set_default_get_variables_from_specific() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         global_vars:
             - name: testvar
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
          parent: default
          global_vars:
             - name: specificvar
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();
@@ -1829,19 +1829,19 @@ mod tests {
   #[test]
   fn test_config_set_specific_dont_inherits_default_global_vars_when_exclude_is_on() {
     let (data_dir, package_dir) = create_temp_espanso_directories_with_default_content(
-      r###"
+      r#"
         global_vars:
             - name: testvar
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     create_user_config_file(
       data_dir.path(),
       "specific.yml",
-      r###"
+      r#"
          exclude_default_entries: true
 
          global_vars:
@@ -1849,7 +1849,7 @@ mod tests {
               type: date
               params:
                 format: "%m"
-        "###,
+        "#,
     );
 
     let config_set = LegacyConfigSet::load(data_dir.path(), package_dir.path()).unwrap();

--- a/espanso-config/src/lib.rs
+++ b/espanso-config/src/lib.rs
@@ -220,7 +220,7 @@ mod tests {
       .unwrap();
 
       let config_file = config_dir.join("default.yml");
-      std::fs::write(config_file, r#""#).unwrap();
+      std::fs::write(config_file, r"").unwrap();
 
       let custom_config_file = config_dir.join("custom.yml");
       std::fs::write(
@@ -261,7 +261,7 @@ mod tests {
       .unwrap();
 
       let config_file = config_dir.join("default.yml");
-      std::fs::write(config_file, r#""#).unwrap();
+      std::fs::write(config_file, r"").unwrap();
 
       let (config_store, match_store, errors) = load(base).unwrap();
 
@@ -285,11 +285,11 @@ mod tests {
       let base_file = match_dir.join("base.yml");
       std::fs::write(
         base_file,
-        r#"
+        r"
       matches:
         - trigger: hello
           replace: world
-      "#,
+      ",
       )
       .unwrap();
 

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -350,9 +350,11 @@ mod tests {
 
   fn create_match(yaml: &str) -> Result<Match> {
     let (m, warnings) = create_match_with_warnings(yaml, false)?;
-    if !warnings.is_empty() {
-      panic!("warnings were detected but not handled: {:?}", warnings);
-    }
+    assert!(
+      warnings.is_empty(),
+      "warnings were detected but not handled: {:?}",
+      warnings
+    );
     Ok(m)
   }
 

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -871,8 +871,8 @@ mod tests {
       assert_eq!(non_fatal_error_set.unwrap().errors.len(), 1);
 
       // Reset the ids to compare them correctly
-      group.matches.iter_mut().for_each(|mut m| m.id = 0);
-      group.global_vars.iter_mut().for_each(|mut v| v.id = 0);
+      group.matches.iter_mut().for_each(|m| m.id = 0);
+      group.global_vars.iter_mut().for_each(|v| v.id = 0);
 
       let vars = vec![Variable {
         name: "var1".to_string(),

--- a/espanso-config/src/matches/group/loader/yaml/mod.rs
+++ b/espanso-config/src/matches/group/loader/yaml/mod.rs
@@ -908,11 +908,11 @@ mod tests {
       let base_file = match_dir.join("base.yml");
       std::fs::write(
         &base_file,
-        r#"
+        r"
       imports:
         - invalid
        - indentation
-      "#,
+      ",
       )
       .unwrap();
 

--- a/espanso-engine/src/process/middleware/disable.rs
+++ b/espanso-engine/src/process/middleware/disable.rs
@@ -128,8 +128,7 @@ fn is_toggle_key(event: &KeyboardEvent, options: &DisableOptions) -> bool {
   if options
     .toggle_key
     .as_ref()
-    .map(|key| key == &event.key)
-    .unwrap_or(false)
+    .is_some_and(|key| key == &event.key)
   {
     if let (Some(variant), Some(e_variant)) = (&options.toggle_key_variant, &event.variant) {
       variant == e_variant

--- a/espanso-engine/src/process/middleware/discard.rs
+++ b/espanso-engine/src/process/middleware/discard.rs
@@ -24,7 +24,7 @@ use log::trace;
 use super::super::Middleware;
 use crate::event::{Event, EventType, SourceId};
 
-/// This middleware discards all events that have a source_id between
+/// This middleware discards all events that have a `source_id` between
 /// the given maximum and minimum.
 /// This useful to discard past events that might have been stuck in the
 /// event queue for too long, or events generated while the search bar was open.

--- a/espanso-engine/src/process/middleware/image_resolve.rs
+++ b/espanso-engine/src/process/middleware/image_resolve.rs
@@ -49,7 +49,7 @@ impl<'a> Middleware for ImageResolverMiddleware<'a> {
       let path = if cfg!(target_os = "windows") {
         m_event.image_path.replace('/', "\\")
       } else {
-        m_event.image_path.to_owned()
+        m_event.image_path.clone()
       };
 
       let path = if path.contains("$CONFIG") {

--- a/espanso-engine/src/process/middleware/matcher.rs
+++ b/espanso-engine/src/process/middleware/matcher.rs
@@ -183,10 +183,7 @@ impl<'a, State> Middleware for MatcherMiddleware<'a, State> {
 fn is_event_of_interest(event_type: &EventType) -> bool {
   match event_type {
     EventType::Keyboard(keyboard_event) => {
-      if keyboard_event.status != Status::Pressed {
-        // Skip non-press events
-        false
-      } else {
+      if keyboard_event.status == Status::Pressed {
         // Skip linux Keyboard (XKB) Extension function and modifier keys
         // In hex, they have the byte 3 = 0xfe
         // See list in "keysymdef.h" file
@@ -203,6 +200,9 @@ fn is_event_of_interest(event_type: &EventType) -> bool {
           keyboard_event.key,
           Key::Alt | Key::Shift | Key::CapsLock | Key::Meta | Key::NumLock | Key::Control
         )
+      } else {
+        // Skip non-press events
+        false
       }
     }
     EventType::Mouse(mouse_event) => mouse_event.status == Status::Pressed,

--- a/espanso-engine/src/process/middleware/multiplex.rs
+++ b/espanso-engine/src/process/middleware/multiplex.rs
@@ -43,12 +43,11 @@ impl<'a> Middleware for MultiplexMiddleware<'a> {
 
   fn next(&self, event: Event, _: &mut dyn FnMut(Event)) -> Event {
     if let EventType::CauseCompensatedMatch(m_event) = event.etype {
-      return match self.multiplexer.convert(m_event.m) {
-        Some(new_event) => Event::caused_by(event.source_id, new_event),
-        None => {
-          error!("match multiplexing failed");
-          Event::caused_by(event.source_id, EventType::NOOP)
-        }
+      return if let Some(new_event) = self.multiplexer.convert(m_event.m) {
+        Event::caused_by(event.source_id, new_event)
+      } else {
+        error!("match multiplexing failed");
+        Event::caused_by(event.source_id, EventType::NOOP)
       };
     }
 

--- a/espanso-engine/src/process/middleware/render.rs
+++ b/espanso-engine/src/process/middleware/render.rs
@@ -85,24 +85,22 @@ impl<'a> Middleware for RenderMiddleware<'a> {
             }),
           );
         }
-        Err(err) => match err.downcast_ref::<RendererError>() {
-          Some(RendererError::Aborted) => {
-            return Event::caused_by(event.source_id, EventType::NOOP)
+        Err(err) => {
+          if let Some(RendererError::Aborted) = err.downcast_ref::<RendererError>() {
+            return Event::caused_by(event.source_id, EventType::NOOP);
           }
-          _ => {
-            error!("error during rendering: {:?}", err);
+          error!("error during rendering: {:?}", err);
 
-            dispatch(Event::caused_by(
-                event.source_id,
-                EventType::TextInject(TextInjectRequest {
-                  text: "[Espanso]: An error occurred during rendering, please examine the logs for more information.".to_string(),
-                  ..Default::default()
-                }),
-              ));
+          dispatch(Event::caused_by(
+                    event.source_id,
+                    EventType::TextInject(TextInjectRequest {
+                      text: "[Espanso]: An error occurred during rendering, please examine the logs for more information.".to_string(),
+                      ..Default::default()
+                    }),
+                  ));
 
-            return Event::caused_by(event.source_id, EventType::RenderingError);
-          }
-        },
+          return Event::caused_by(event.source_id, EventType::RenderingError);
+        }
       }
     }
 

--- a/espanso-info/src/win32/mod.rs
+++ b/espanso-info/src/win32/mod.rs
@@ -46,7 +46,9 @@ impl AppInfoProvider for WinAppInfoProvider {
 impl WinAppInfoProvider {
   fn get_exec() -> Option<String> {
     let mut buffer: [u16; 2048] = [0; 2048];
-    if unsafe { info_get_exec(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } != 0 {
+    if unsafe { info_get_exec(buffer.as_mut_ptr(), (buffer.len() - 1) as i32) } == 0 {
+      None
+    } else {
       let string = unsafe { U16CStr::from_ptr_str(buffer.as_ptr()) };
       let string = string.to_string_lossy();
       if string.is_empty() {
@@ -54,8 +56,6 @@ impl WinAppInfoProvider {
       } else {
         Some(string)
       }
-    } else {
-      None
     }
   }
 

--- a/espanso-match/src/regex/mod.rs
+++ b/espanso-match/src/regex/mod.rs
@@ -179,7 +179,7 @@ mod tests {
   fn match_result<Id: Default>(id: Id, trigger: &str, vars: &[(&str, &str)]) -> MatchResult<Id> {
     let vars: HashMap<String, String> = vars
       .iter()
-      .map(|(key, value)| (key.to_string(), value.to_string()))
+      .map(|(key, value)| ((*key).to_string(), (*value).to_string()))
       .collect();
 
     MatchResult {

--- a/espanso-modulo/src/form/config.rs
+++ b/espanso-modulo/src/form/config.rs
@@ -100,7 +100,7 @@ impl<'a> From<&'a AutoFieldConfig> for FieldConfig {
   fn from(other: &'a AutoFieldConfig) -> Self {
     let field_type = match other.field_type.as_ref() {
       "text" => {
-        let mut config: TextFieldConfig = Default::default();
+        let mut config = TextFieldConfig::default();
 
         if let Some(default) = &other.default {
           config.default = default.clone();

--- a/espanso-modulo/src/form/generator.rs
+++ b/espanso-modulo/src/form/generator.rs
@@ -39,7 +39,7 @@ fn create_field(token: &Token, field_map: &HashMap<String, FieldConfig>) -> Fiel
       let config = if let Some(config) = field_map.get(name) {
         config.clone()
       } else {
-        Default::default()
+        FieldConfig::default()
       };
 
       let field_type = match &config.field_type {

--- a/espanso-modulo/src/sys/troubleshooting/mod.rs
+++ b/espanso-modulo/src/sys/troubleshooting/mod.rs
@@ -35,6 +35,7 @@ lazy_static! {
 
 #[allow(dead_code)]
 mod interop {
+  use crate::sys;
   use crate::troubleshooting::{ErrorRecord, ErrorSet};
 
   use super::interop::{ErrorMetadata, ErrorSetMetadata};
@@ -73,8 +74,10 @@ mod interop {
 
       let errors: Vec<OwnedErrorMetadata> = error_set.errors.iter().map(Into::into).collect();
 
-      let interop_errors: Vec<ErrorMetadata> =
-        errors.iter().map(|item| item.to_error_metadata()).collect();
+      let interop_errors: Vec<ErrorMetadata> = errors
+        .iter()
+        .map(sys::troubleshooting::interop::OwnedErrorMetadata::to_error_metadata)
+        .collect();
 
       Self {
         file_path,

--- a/espanso-package/src/archive/default.rs
+++ b/espanso-package/src/archive/default.rs
@@ -186,9 +186,9 @@ matches:
 
     write(
       package_dir.join("README.md"),
-      r#"
+      r"
     A very dummy package
-    "#,
+    ",
     )
     .unwrap();
 

--- a/espanso-package/src/resolver.rs
+++ b/espanso-package/src/resolver.rs
@@ -113,13 +113,13 @@ mod tests {
     run_with_temp_dir(|base_dir| {
       std::fs::write(
         base_dir.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
       version: 0.1.0
       description: An awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -150,13 +150,13 @@ mod tests {
 
       std::fs::write(
         version_dir1.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
       version: 0.1.0
       description: An awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -166,13 +166,13 @@ mod tests {
 
       std::fs::write(
         version_dir2.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
       version: 0.1.1
       description: An awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -181,13 +181,13 @@ mod tests {
 
       std::fs::write(
         sub_dir3.join("_manifest.yml"),
-        r#"
+        r"
       name: package2
       title: Package 2
       author: Federico
       version: 2.0.0
       description: Another awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -240,13 +240,13 @@ mod tests {
 
       std::fs::write(
         version_dir1.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
       version: 0.1.0
       description: An awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -256,13 +256,13 @@ mod tests {
 
       std::fs::write(
         version_dir2.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
       version: 0.1.1
       description: An awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -271,13 +271,13 @@ mod tests {
 
       std::fs::write(
         sub_dir3.join("_manifest.yml"),
-        r#"
+        r"
       name: package2
       title: Package 2
       author: Federico
       version: 2.0.0
       description: Another awesome package 
-      "#,
+      ",
       )
       .unwrap();
 
@@ -340,11 +340,11 @@ mod tests {
     run_with_temp_dir(|base_dir| {
       std::fs::write(
         base_dir.join("_manifest.yml"),
-        r#"
+        r"
       name: package1
       title: Package 1
       author: Federico
-      "#,
+      ",
       )
       .unwrap();
 

--- a/espanso-render/src/extension/clipboard.rs
+++ b/espanso-render/src/extension/clipboard.rs
@@ -57,6 +57,8 @@ pub enum ClipboardExtensionError {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use super::*;
 
   struct MockClipboardProvider {
@@ -80,7 +82,11 @@ mod tests {
 
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &Params::new())
+        .calculate(
+          &crate::Context::default(),
+          &HashMap::default(),
+          &Params::new()
+        )
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("test".to_string())
@@ -93,7 +99,11 @@ mod tests {
     let extension = ClipboardExtension::new(&provider);
 
     assert!(matches!(
-      extension.calculate(&Default::default(), &Default::default(), &Params::new()),
+      extension.calculate(
+        &crate::Context::default(),
+        &HashMap::default(),
+        &Params::new()
+      ),
       ExtensionResult::Error(_)
     ));
   }

--- a/espanso-render/src/extension/date.rs
+++ b/espanso-render/src/extension/date.rs
@@ -422,6 +422,8 @@ impl DefaultLocaleProvider {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use super::*;
   use chrono::offset::TimeZone;
 
@@ -456,7 +458,7 @@ mod tests {
       .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("09:10:11".to_string())
@@ -477,7 +479,7 @@ mod tests {
     .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("10:10:11".to_string())
@@ -495,7 +497,7 @@ mod tests {
       .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("martedì".to_string())
@@ -513,7 +515,7 @@ mod tests {
       .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("Tuesday".to_string())
@@ -534,7 +536,7 @@ mod tests {
     .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("martedì".to_string())

--- a/espanso-render/src/extension/date.rs
+++ b/espanso-render/src/extension/date.rs
@@ -64,8 +64,7 @@ impl<'a> Extension for DateExtension<'a> {
     let locale = params
       .get("locale")
       .and_then(|val| val.as_string())
-      .map(String::from)
-      .unwrap_or_else(|| self.locale_provider.get_system_locale());
+      .map_or_else(|| self.locale_provider.get_system_locale(), String::from);
 
     let date = if let Some(Value::String(format)) = format {
       DateExtension::format_date_with_locale_string(now, format, &locale)

--- a/espanso-render/src/extension/echo.rs
+++ b/espanso-render/src/extension/echo.rs
@@ -66,6 +66,8 @@ pub enum EchoExtensionError {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use super::*;
 
   #[test]
@@ -77,7 +79,7 @@ mod tests {
       .collect::<Params>();
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("test".to_string())
@@ -90,7 +92,7 @@ mod tests {
 
     let param = Params::new();
     assert!(matches!(
-      extension.calculate(&Default::default(), &Default::default(), &param),
+      extension.calculate(&crate::Context::default(), &HashMap::default(), &param),
       ExtensionResult::Error(_)
     ));
   }

--- a/espanso-render/src/extension/form.rs
+++ b/espanso-render/src/extension/form.rs
@@ -59,9 +59,7 @@ impl<'a> Extension for FormExtension<'a> {
     _: &crate::Scope,
     params: &Params,
   ) -> crate::ExtensionResult {
-    let layout = if let Some(Value::String(layout)) = params.get("layout") {
-      layout
-    } else {
+    let Some(Value::String(layout)) = params.get("layout") else {
       return crate::ExtensionResult::Error(FormExtensionError::MissingLayout.into());
     };
 

--- a/espanso-render/src/extension/random.rs
+++ b/espanso-render/src/extension/random.rs
@@ -70,6 +70,8 @@ pub enum RandomExtensionError {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use super::*;
 
   #[test]
@@ -88,7 +90,7 @@ mod tests {
     .collect::<Params>();
     assert!(matches!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single(result) if ["first", "second", "third"].contains(&result.as_str())
@@ -101,7 +103,7 @@ mod tests {
 
     let param = Params::new();
     assert!(matches!(
-      extension.calculate(&Default::default(), &Default::default(), &param),
+      extension.calculate(&crate::Context::default(), &HashMap::default(), &param),
       ExtensionResult::Error(_)
     ));
   }

--- a/espanso-render/src/extension/script.rs
+++ b/espanso-render/src/extension/script.rs
@@ -175,6 +175,8 @@ pub enum ScriptExtensionError {
 
 #[cfg(test)]
 mod tests {
+  use std::collections::HashMap;
+
   use super::*;
   #[cfg(not(target_os = "windows"))]
   use crate::Scope;
@@ -279,7 +281,7 @@ mod tests {
     .into_iter()
     .collect::<Params>();
     assert!(matches!(
-      extension.calculate(&Default::default(), &Default::default(), &param),
+      extension.calculate(&crate::Context::default(), &HashMap::default(), &param),
       ExtensionResult::Error(_)
     ));
   }

--- a/espanso-render/src/extension/shell.rs
+++ b/espanso-render/src/extension/shell.rs
@@ -311,7 +311,7 @@ mod tests {
     if cfg!(target_os = "windows") {
       assert_eq!(
         extension
-          .calculate(&Default::default(), &Default::default(), &param)
+          .calculate(&crate::Context::default(), &HashMap::default(), &param)
           .into_success()
           .unwrap(),
         ExtensionOutput::Single("hello world\r\n".to_string())
@@ -319,7 +319,7 @@ mod tests {
     } else {
       assert_eq!(
         extension
-          .calculate(&Default::default(), &Default::default(), &param)
+          .calculate(&crate::Context::default(), &HashMap::default(), &param)
           .into_success()
           .unwrap(),
         ExtensionOutput::Single("hello world\n".to_string())
@@ -340,7 +340,7 @@ mod tests {
 
     assert_eq!(
       extension
-        .calculate(&Default::default(), &Default::default(), &param)
+        .calculate(&crate::Context::default(), &HashMap::default(), &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("hello world".to_string())
@@ -393,7 +393,7 @@ mod tests {
     scope.insert("var1", ExtensionOutput::Single("hello world".to_string()));
     assert_eq!(
       extension
-        .calculate(&Default::default(), &scope, &param)
+        .calculate(&crate::Context::default(), &scope, &param)
         .into_success()
         .unwrap(),
       ExtensionOutput::Single("hello world".to_string())
@@ -411,7 +411,7 @@ mod tests {
     .into_iter()
     .collect::<Params>();
     assert!(matches!(
-      extension.calculate(&Default::default(), &Default::default(), &param),
+      extension.calculate(&crate::Context::default(), &HashMap::default(), &param),
       ExtensionResult::Error(_)
     ));
   }

--- a/espanso-render/src/renderer/mod.rs
+++ b/espanso-render/src/renderer/mod.rs
@@ -337,8 +337,8 @@ mod tests {
     let renderer = get_renderer();
     let res = renderer.render(
       &template_for_str("plain body"),
-      &Default::default(),
-      &Default::default(),
+      &Context::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "plain body"));
   }
@@ -348,7 +348,7 @@ mod tests {
     let renderer = get_renderer();
     let res = renderer.render(
       &template_for_str("plain body"),
-      &Default::default(),
+      &Context::default(),
       &RenderOptions {
         casing_style: CasingStyle::Capitalize,
       },
@@ -361,7 +361,7 @@ mod tests {
     let renderer = get_renderer();
     let res = renderer.render(
       &template_for_str("ordinary least squares, with other.punctuation !Marks"),
-      &Default::default(),
+      &Context::default(),
       &RenderOptions {
         casing_style: CasingStyle::CapitalizeWords,
       },
@@ -376,7 +376,7 @@ mod tests {
     let renderer = get_renderer();
     let res = renderer.render(
       &template_for_str("plain body"),
-      &Default::default(),
+      &Context::default(),
       &RenderOptions {
         casing_style: CasingStyle::Uppercase,
       },
@@ -388,7 +388,7 @@ mod tests {
   fn basic_variable() {
     let renderer = get_renderer();
     let template = template("hello {{var}}", &[("var", "world")]);
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello world"));
   }
 
@@ -410,7 +410,7 @@ mod tests {
       }],
       ..Default::default()
     };
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello dict"));
   }
 
@@ -418,7 +418,7 @@ mod tests {
   fn missing_variable() {
     let renderer = get_renderer();
     let template = template_for_str("hello {{var}}");
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Error(_)));
   }
 
@@ -440,7 +440,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello world"));
   }
@@ -465,7 +465,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello dict"));
   }
@@ -506,7 +506,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello Bob Bob"));
   }
@@ -540,7 +540,7 @@ mod tests {
         ],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello world"));
   }
@@ -583,7 +583,7 @@ mod tests {
         ],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Error(_)));
   }
@@ -615,7 +615,7 @@ mod tests {
         ],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Aborted));
   }
@@ -647,7 +647,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Aborted));
   }
@@ -678,7 +678,7 @@ mod tests {
         templates: vec![&nested_template],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello world"));
   }
@@ -703,7 +703,7 @@ mod tests {
       &Context {
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Error(_)));
   }
@@ -723,7 +723,7 @@ mod tests {
       }],
       ..Default::default()
     };
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Aborted));
   }
 
@@ -742,7 +742,7 @@ mod tests {
       }],
       ..Default::default()
     };
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Error(_)));
   }
 
@@ -781,7 +781,7 @@ mod tests {
       },
     ];
 
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello John Snow"));
   }
 
@@ -808,7 +808,7 @@ mod tests {
       },
     ];
 
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello {{first}} two"));
   }
 
@@ -834,7 +834,7 @@ mod tests {
       },
     ];
 
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello {{first}} two"));
   }
 
@@ -852,7 +852,7 @@ mod tests {
       ..Default::default()
     }];
 
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Error(_)));
   }
 
@@ -891,7 +891,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello global"));
   }
@@ -935,7 +935,7 @@ mod tests {
         }],
         ..Default::default()
       },
-      &Default::default(),
+      &RenderOptions::default(),
     );
     assert!(matches!(res, RenderResult::Success(str) if str == "hello local"));
   }
@@ -944,7 +944,7 @@ mod tests {
   fn variable_escape() {
     let renderer = get_renderer();
     let template = template("hello \\{\\{var\\}\\}", &[("var", "world")]);
-    let res = renderer.render(&template, &Default::default(), &Default::default());
+    let res = renderer.render(&template, &Context::default(), &RenderOptions::default());
     assert!(matches!(res, RenderResult::Success(str) if str == "hello {{var}}"));
   }
 }

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -171,7 +171,8 @@ fn resolve_dependencies<'a>(
       if !has_been_resolved {
         if has_been_seen {
           return Err(
-            RendererError::CircularDependency(node.name.to_string(), dependency.to_string()).into(),
+            RendererError::CircularDependency(node.name.to_string(), (*dependency).to_string())
+              .into(),
           );
         }
 
@@ -186,7 +187,7 @@ fn resolve_dependencies<'a>(
                 super::log_new_form_syntax_tip();
               }
             }
-            return Err(RendererError::MissingVariable(dependency.to_string()).into());
+            return Err(RendererError::MissingVariable((*dependency).to_string()).into());
           }
         }
       }

--- a/espanso-render/src/renderer/resolve.rs
+++ b/espanso-render/src/renderer/resolve.rs
@@ -176,19 +176,16 @@ fn resolve_dependencies<'a>(
           );
         }
 
-        match node_map.get(dependency) {
-          Some(dependency_node) => {
-            resolve_dependencies(dependency_node, node_map, eval_order, resolved, seen)?;
-          }
-          None => {
-            error!("could not resolve variable {:?}", dependency);
-            if let Some(variable) = &node.variable {
-              if variable.var_type == "form" {
-                super::log_new_form_syntax_tip();
-              }
+        if let Some(dependency_node) = node_map.get(dependency) {
+          resolve_dependencies(dependency_node, node_map, eval_order, resolved, seen)?;
+        } else {
+          error!("could not resolve variable {:?}", dependency);
+          if let Some(variable) = &node.variable {
+            if variable.var_type == "form" {
+              super::log_new_form_syntax_tip();
             }
-            return Err(RendererError::MissingVariable((*dependency).to_string()).into());
           }
+          return Err(RendererError::MissingVariable((*dependency).to_string()).into());
         }
       }
     }

--- a/espanso-render/src/renderer/util.rs
+++ b/espanso-render/src/renderer/util.rs
@@ -72,29 +72,27 @@ pub(crate) fn render_variables(body: &str, scope: &Scope) -> Result<String> {
     .replace_all(body, |caps: &Captures| {
       let var_name = caps.name("name").unwrap().as_str();
       let var_subname = caps.name("subname");
-      match scope.get(var_name) {
-        Some(output) => match output {
+      if let Some(output) = scope.get(var_name) {
+        match output {
           ExtensionOutput::Single(output) => output,
-          ExtensionOutput::Multiple(results) => match var_subname {
-            Some(var_subname) => {
+          ExtensionOutput::Multiple(results) => {
+            if let Some(var_subname) = var_subname {
               let var_subname = var_subname.as_str();
               results.get(var_subname).map_or("", |value| value)
-            }
-            None => {
+            } else {
               error!("nested name missing from multi-value variable: {var_name}");
               replacing_error = Some(RendererError::MissingVariable(format!(
                 "nested name missing from multi-value variable: {var_name}"
               )));
               ""
             }
-          },
-        },
-        None => {
-          replacing_error = Some(RendererError::MissingVariable(format!(
-            "variable '{var_name}' is missing"
-          )));
-          ""
+          }
         }
+      } else {
+        replacing_error = Some(RendererError::MissingVariable(format!(
+          "variable '{var_name}' is missing"
+        )));
+        ""
       }
     })
     .to_string();

--- a/espanso/src/cli/launcher/mod.rs
+++ b/espanso/src/cli/launcher/mod.rs
@@ -86,7 +86,7 @@ fn launcher_main(args: CliModuleArgs) -> i32 {
   let paths_clone = paths.clone();
   let backup_and_migrate_handler =
     Box::new(move || match util::migrate_configuration(&paths_clone) {
-      Ok(_) => MigrationResult::Success,
+      Ok(()) => MigrationResult::Success,
       Err(error) => match error.downcast_ref::<MigrationError>() {
         Some(MigrationError::Dirty) => MigrationResult::DirtyFailure,
         Some(MigrationError::Clean) => MigrationResult::CleanFailure,
@@ -102,7 +102,7 @@ fn launcher_main(args: CliModuleArgs) -> i32 {
 
     if auto_start {
       match util::configure_auto_start(true) {
-        Ok(_) => true,
+        Ok(()) => true,
         Err(error) => {
           eprintln!("Service register returned error: {error}");
           false
@@ -126,7 +126,7 @@ fn launcher_main(args: CliModuleArgs) -> i32 {
       false
     };
   let add_to_path_handler = Box::new(move || match util::add_espanso_to_path() {
-    Ok(_) => true,
+    Ok(()) => true,
     Err(error) => {
       eprintln!("Add to path returned error: {error}");
       false

--- a/espanso/src/cli/match_cli/exec.rs
+++ b/espanso/src/cli/match_cli/exec.rs
@@ -33,7 +33,7 @@ pub fn exec_main(cli_args: &ArgMatches, paths: &Paths) -> Result<()> {
   let trigger = cli_args.value_of("trigger");
   let args = cli_args.values_of("arg");
 
-  if trigger.is_none() || trigger.map(str::is_empty).unwrap_or(false) {
+  if trigger.is_none() || trigger.is_some_and(str::is_empty) {
     bail!("You need to specify the --trigger 'trigger' option. Run `espanso match exec --help` for more information.");
   }
 

--- a/espanso/src/cli/worker/engine/funnel/modifier.rs
+++ b/espanso/src/cli/worker/engine/funnel/modifier.rs
@@ -178,7 +178,7 @@ impl espanso_engine::process::ModifierStateProvider for ModifierStateStore {
           Modifier::Meta => {
             is_meta_down = true;
           }
-          _ => {}
+          Modifier::Shift => {}
         }
       }
     }

--- a/espanso/src/cli/worker/engine/mod.rs
+++ b/espanso/src/cli/worker/engine/mod.rs
@@ -21,6 +21,7 @@ use std::thread::JoinHandle;
 
 use anyhow::Result;
 use crossbeam::channel::Receiver;
+use espanso_clipboard::ClipboardOptions;
 use espanso_config::{config::ConfigStore, matches::store::MatchStore};
 use espanso_detect::SourceCreationOptions;
 use espanso_engine::event::{EventType, ExitMode};
@@ -182,7 +183,7 @@ pub fn initialize_and_spawn(
         ..Default::default()
       })
       .expect("failed to initialize injector module"); // TODO: handle the options
-      let clipboard = espanso_clipboard::get_clipboard(Default::default())
+      let clipboard = espanso_clipboard::get_clipboard(ClipboardOptions::default())
         .expect("failed to initialize clipboard module"); // TODO: handle options
 
       let clipboard_adapter = ClipboardAdapter::new(&*clipboard, &config_manager);

--- a/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/extension/form.rs
@@ -85,7 +85,7 @@ fn convert_fields(fields: &Params) -> HashMap<String, FormField> {
           multiline: params
             .get("multiline")
             .and_then(|val| val.as_bool())
-            .cloned()
+            .copied()
             .unwrap_or(false),
         }),
       }
@@ -109,7 +109,7 @@ fn extract_values(value: &Value, trim_string_values: Option<&Value>) -> Option<V
     Value::Array(values) => Some(
       values
         .iter()
-        .flat_map(|choice| choice.as_string())
+        .filter_map(|choice| choice.as_string())
         .cloned()
         .collect(),
     ),

--- a/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
+++ b/espanso/src/cli/worker/engine/process/middleware/render/mod.rs
@@ -202,7 +202,7 @@ impl<'a> Renderer<'a> for RendererAdapter<'a> {
         .or_insert_with(|| generate_context(&match_set, &self.template_map, &self.global_vars_map));
 
       let raw_match = self.match_provider.get(match_id);
-      let propagate_case = raw_match.map(is_propagate_case).unwrap_or(false);
+      let propagate_case = raw_match.is_some_and(is_propagate_case);
       let preferred_uppercasing_style = raw_match.and_then(extract_uppercasing_style);
 
       let options = RenderOptions {

--- a/espanso/src/exit_code.rs
+++ b/espanso/src/exit_code.rs
@@ -97,19 +97,16 @@ pub fn configure_custom_panic_hook() {
       },
     };
 
-    match info.location() {
-      Some(location) => {
-        error_eprintln!(
-          "ERROR: '{}' panicked at '{}': {}:{}",
-          thread,
-          msg,
-          location.file(),
-          location.line(),
-        );
-      }
-      None => {
-        error_eprintln!("ERROR: '{}' panicked at '{}'", thread, msg);
-      }
+    if let Some(location) = info.location() {
+      error_eprintln!(
+        "ERROR: '{}' panicked at '{}': {}:{}",
+        thread,
+        msg,
+        location.file(),
+        location.line(),
+      );
+    } else {
+      error_eprintln!("ERROR: '{}' panicked at '{}'", thread, msg);
     }
 
     let exit_code = CURRENT_PANIC_EXIT_CODE.lock().unwrap();

--- a/espanso/src/gui/modulo/manager.rs
+++ b/espanso/src/gui/modulo/manager.rs
@@ -59,7 +59,7 @@ impl ModuloManager {
         Ok(mut child) => {
           if let Some(stdin) = child.stdin.as_mut() {
             match stdin.write_all(body.as_bytes()) {
-              Ok(_) => Ok(()),
+              Ok(()) => Ok(()),
               Err(error) => Err(ModuloError::Error(error).into()),
             }
           } else {
@@ -93,7 +93,7 @@ impl ModuloManager {
         Ok(mut child) => {
           if let Some(stdin) = child.stdin.as_mut() {
             match stdin.write_all(body.as_bytes()) {
-              Ok(_) => {
+              Ok(()) => {
                 // Get the output
                 match child.wait_with_output() {
                   Ok(child_output) => {


### PR DESCRIPTION
Hi! 
from #1775 I had a good chunk of fixes landed, so kept going!

used command
```console
cargo clippy --all-targets -- -W clippy::pedantic -A clippy::too_many_lines -A clippy::needless_pass_by_value -A clippy::missing_errors_doc -A clippy::missing_panics_doc -A clippy::cast_possible_wrap -A clippy::module_name_repetitions -A clippy::match_same_arms -A clippy::unnecessary_wraps -A clippy::cast_possible_truncation -A clippy::must_use_candidate -A clippy::similar_names -A clippy::struct_excessive_bools -A clippy::wildcard_imports -A clippy::items_after_statements -A clippy::used_underscore_binding -A clippy::borrow_as_ptr -A clippy::no_effect_underscore_binding -A clippy::cast_sign_loss -A clippy::ptr_as_ptr
```

or,  you can see the lints on VS Code with the config on `settings.json`:

<details>

```json
  "rust-analyzer.check.command": "clippy",
  "rust-analyzer.check.extraArgs": [
    // "--all-targets", // it doesnt work with this flag
    "--",
    "-W",
    "clippy::pedantic",
    "-A",
    "clippy::too_many_lines",
    "-A",
    "clippy::needless_pass_by_value",
    "-A",
    "clippy::missing_errors_doc",
    "-A",
    "clippy::missing_panics_doc",
    "-A",
    "clippy::cast_possible_wrap",
    "-A",
    "clippy::module_name_repetitions",
    "-A",
    "clippy::match_same_arms",
    "-A",
    "clippy::unnecessary_wraps",
    "-A",
    "clippy::cast_possible_truncation",
    "-A",
    "clippy::cast_sign_loss",
    "-A",
    "clippy::ptr_as_ptr",
    "-A",
    "clippy::as_conversions",
    "-A",
    "clippy::used_underscore_binding",
    "-A",
    "clippy::no_effect_underscore_binding",
    "-A",
    "clippy::borrow_as_ptr",
    "-A",
    "clippy::must_use_candidate",
    "-A",
    "clippy::similar_names",
    "-A",
    "clippy::struct_excessive_bools",
    "-A",
    "clippy::wildcard_imports",
    "-A",
    "clippy::items_after_statements",
    "-A",
    "clippy::used_underscore_binding",
    "-A",
    "clippy::module_name_repetitions"
  ],
```


</details>