### PR TITLE
:green_heart: Add `fail-fast: true` to stop the CI with fails

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ env:
 jobs:
   build:
     strategy:
-      fail-fast: false
+      fail-fast: true
       matrix:
         os: [windows-latest, macos-latest, ubuntu-latest]
 


### PR DESCRIPTION
Just a tiny line change, 
```yaml
    fail-fast:true
```
Does that when any check is red, stops the workflow entirely, so don't waste resources that we don't need 😄 