### PR TITLE
Fix: Make search window resizeable on Windows and Linux

### DIFF
--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -34,7 +34,7 @@
 // Platform-specific styles
 #ifdef __WXMSW__
 const int SEARCH_BAR_FONT_SIZE = 16;
-const long DEFAULT_STYLE = wxSTAY_ON_TOP | wxFRAME_TOOL_WINDOW;
+const long DEFAULT_STYLE = wxSTAY_ON_TOP | wxFRAME_TOOL_WINDOW | wxRESIZE_BORDER;
 #endif
 #ifdef __WXOSX__
 const int SEARCH_BAR_FONT_SIZE = 20;
@@ -271,7 +271,9 @@ SearchFrame::SearchFrame(const wxString &title, const wxPoint &pos,
         Bind(wxEVT_LEAVE_WINDOW, &SearchFrame::OnMouseLeave, this);
     }
 
-    this->SetClientSize(panel->GetBestSize());
+    wxSize bestSize = panel->GetBestSize();
+    this->SetClientSize(bestSize);
+    this->SetSizeHints(MIN_WIDTH, MIN_HEIGHT);
     this->CentreOnScreen();
 
     // Trigger the first data update

--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -42,7 +42,7 @@ const long DEFAULT_STYLE = wxSTAY_ON_TOP | wxRESIZE_BORDER;
 #endif
 #ifdef __LINUX__
 const int SEARCH_BAR_FONT_SIZE = 20;
-const long DEFAULT_STYLE = wxSTAY_ON_TOP;
+const long DEFAULT_STYLE = wxSTAY_ON_TOP | wxRESIZE_BORDER;
 #endif
 
 const int HELP_TEXT_FONT_SIZE = 10;


### PR DESCRIPTION
## Changes
- Added wxRESIZE_BORDER flag to Windows and Linux styles
- Changed SetClientSize to SetClientHints to allow user resizing
- Maintains minimum size constraints (MIN_WIDTH x MIN_HEIGHT)

Tested on Windows 11: Fully working and resizeable

Tested in Linux VM: App loads and runs proper, but due to VM constraints, I'm not positive the resize works.

@AucaCoyan @smeech Could you guys test this on both Windows and/or Linux? My first PR as lead and want to make sure I followed conventions correctly.

## Related Issues
- Closes #1941 (recent request)
- Related to Discussion [1241](https://github.com/espanso/espanso/discussions/1241)