### PR TITLE
fix(wayland): copied text not paste-able in some programs

### DIFF
--- a/espanso-clipboard/src/wayland/fallback/mod.rs
+++ b/espanso-clipboard/src/wayland/fallback/mod.rs
@@ -119,7 +119,15 @@ impl Clipboard for WaylandFallbackClipboard {
     }
 
     fn set_text(&self, text: &str, _: &ClipboardOperationOptions) -> anyhow::Result<()> {
-        self.invoke_command_with_timeout(&mut Command::new("wl-copy"), text.as_bytes(), "wl-copy")
+        // NOTE: Without explicit MIME type, wl-copy's auto-detection can give unexpected results
+        // making the text not paste-able in some programs.
+        self.invoke_command_with_timeout(
+            Command::new("wl-copy")
+                .arg("--type")
+                .arg("text/plain;charset=utf-8"),
+            text.as_bytes(),
+            "wl-copy",
+        )
     }
 
     fn set_image(

--- a/espanso-clipboard/src/wayland/fallback/mod.rs
+++ b/espanso-clipboard/src/wayland/fallback/mod.rs
@@ -77,45 +77,13 @@ impl WaylandFallbackClipboard {
 
 impl Clipboard for WaylandFallbackClipboard {
     fn get_text(&self, _: &ClipboardOperationOptions) -> Option<String> {
-        let timeout = std::time::Duration::from_millis(self.command_timeout);
-        match Command::new("wl-paste")
-            .arg("--no-newline")
-            .stdout(Stdio::piped())
-            .spawn()
-        {
-            Ok(mut child) => match child.wait_timeout(timeout) {
-                Ok(status_code) => {
-                    if let Some(status) = status_code {
-                        if status.success() {
-                            if let Some(mut io) = child.stdout {
-                                let mut output = Vec::new();
-                                io.read_to_end(&mut output).ok()?;
-                                Some(String::from_utf8_lossy(&output).to_string())
-                            } else {
-                                None
-                            }
-                        } else {
-                            error!("error, wl-paste exited with non-zero exit code");
-                            None
-                        }
-                    } else {
-                        error!("error, wl-paste has timed-out, killing the process");
-                        if child.kill().is_err() {
-                            error!("unable to kill wl-paste");
-                        }
-                        None
-                    }
-                }
-                Err(err) => {
-                    error!("error while executing 'wl-paste': {}", err);
-                    None
-                }
-            },
-            Err(err) => {
-                error!("could not invoke 'wl-paste': {}", err);
-                None
-            }
-        }
+        // FIXME: I want to use invoke_command_with_timeout (or similar) to run the program without input & get output
+        let cmd = Command::new("wl-paste").arg("--no-newline").stdout(Stdio::piped());
+        self.invoke_command_with_timeout(
+            &mut cmd,
+            None,
+            "wl-paste",
+        ).ok()
     }
 
     fn set_text(&self, text: &str, _: &ClipboardOperationOptions) -> anyhow::Result<()> {
@@ -125,9 +93,9 @@ impl Clipboard for WaylandFallbackClipboard {
             Command::new("wl-copy")
                 .arg("--type")
                 .arg("text/plain;charset=utf-8"),
-            text.as_bytes(),
+            Some(text.as_bytes()),
             "wl-copy",
-        )
+        ).map(|_| ())
     }
 
     fn set_image(
@@ -148,9 +116,9 @@ impl Clipboard for WaylandFallbackClipboard {
 
         self.invoke_command_with_timeout(
             Command::new("wl-copy").arg("--type").arg("image/png"),
-            &data,
+            Some(&data),
             "wl-copy",
-        )
+        ).map(|_| ())
     }
 
     fn set_html(
@@ -161,30 +129,48 @@ impl Clipboard for WaylandFallbackClipboard {
     ) -> anyhow::Result<()> {
         self.invoke_command_with_timeout(
             Command::new("wl-copy").arg("--type").arg("text/html"),
-            html.as_bytes(),
+            Some(html.as_bytes()),
             "wl-copy",
-        )
+        ).map(|_| ())
     }
 }
 
 impl WaylandFallbackClipboard {
     fn invoke_command_with_timeout(
         &self,
-        command: &mut Command,
-        data: &[u8],
+        mut command: &mut Command,
+        // IDEA: (input_data, output_data): (Option<&[u8]>, Option<&mut String>) 🤔
+        // BUT then we no longer need the output in Result 🤔
+        // .. OR DO SOMETHING ELSE ENTIRELY 🤔
+        input_data: Option<&[u8]>,
         name: &str,
-    ) -> Result<()> {
+    ) -> Result<String> {
         let timeout = std::time::Duration::from_millis(self.command_timeout);
-        match command.stdin(Stdio::piped()).spawn() {
+
+        if input_data.is_some() {
+            command = command.stdin(Stdio::piped());
+        } else {
+            command = command.stdout(Stdio::piped());
+        }
+
+        match command.spawn() {
             Ok(mut child) => {
-                if let Some(stdin) = child.stdin.as_mut() {
+                if let Some(data) = input_data {
+                    let stdin = child.stdin.as_mut().ok_or_else(|| anyhow::anyhow!("Unable to open stdin"))?;
                     stdin.write_all(data)?;
                 }
                 match child.wait_timeout(timeout) {
                     Ok(status_code) => {
                         if let Some(status) = status_code {
                             if status.success() {
-                                Ok(())
+                                // TODO: check if output expected
+                                if let Some(mut io) = child.stdout {
+                                    let mut output = Vec::new();
+                                    io.read_to_end(&mut output)?;
+                                    Ok(String::from_utf8_lossy(&output).to_string())
+                                } else {
+                                    Ok(String::new())
+                                }
                             } else {
                                 error!("error, {} exited with non-zero exit code", name);
                                 Err(WaylandFallbackClipboardError::SetOperationFailed().into())
@@ -194,6 +180,7 @@ impl WaylandFallbackClipboard {
                             if child.kill().is_err() {
                                 error!("unable to kill {}", name);
                             }
+                            // FIXME: might not be a 'Set' operation that failed anymore 🤔
                             Err(WaylandFallbackClipboardError::SetOperationFailed().into())
                         }
                     }

--- a/espanso-clipboard/src/wayland/fallback/mod.rs
+++ b/espanso-clipboard/src/wayland/fallback/mod.rs
@@ -77,25 +77,33 @@ impl WaylandFallbackClipboard {
 
 impl Clipboard for WaylandFallbackClipboard {
     fn get_text(&self, _: &ClipboardOperationOptions) -> Option<String> {
-        // FIXME: I want to use invoke_command_with_timeout (or similar) to run the program without input & get output
-        let cmd = Command::new("wl-paste").arg("--no-newline").stdout(Stdio::piped());
+        let mut command = Command::new("wl-paste");
+        command.arg("--no-newline");
+
+        let mut output = String::new();
+
         self.invoke_command_with_timeout(
-            &mut cmd,
+            command,
             None,
-            "wl-paste",
-        ).ok()
+            Some(&mut output),
+            ClipboardAction::Get,
+        )
+        .map(|_| output)
+        .ok()
     }
 
     fn set_text(&self, text: &str, _: &ClipboardOperationOptions) -> anyhow::Result<()> {
         // NOTE: Without explicit MIME type, wl-copy's auto-detection can give unexpected results
         // making the text not paste-able in some programs.
+        let mut command = Command::new("wl-copy");
+        command.arg("--type").arg("text/plain;charset=utf-8");
+
         self.invoke_command_with_timeout(
-            Command::new("wl-copy")
-                .arg("--type")
-                .arg("text/plain;charset=utf-8"),
+            command,
             Some(text.as_bytes()),
-            "wl-copy",
-        ).map(|_| ())
+            None,
+            ClipboardAction::Set,
+        )
     }
 
     fn set_image(
@@ -114,11 +122,15 @@ impl Clipboard for WaylandFallbackClipboard {
         let mut data = Vec::new();
         file.read_to_end(&mut data)?;
 
+        let mut command = Command::new("wl-copy");
+        command.arg("--type").arg("image/png");
+
         self.invoke_command_with_timeout(
-            Command::new("wl-copy").arg("--type").arg("image/png"),
+            command,
             Some(&data),
-            "wl-copy",
-        ).map(|_| ())
+            None,
+            ClipboardAction::Set,
+        )
     }
 
     fn set_html(
@@ -127,73 +139,104 @@ impl Clipboard for WaylandFallbackClipboard {
         _fallback_text: Option<&str>,
         _: &ClipboardOperationOptions,
     ) -> anyhow::Result<()> {
+        let mut command = Command::new("wl-copy");
+        command.arg("--type").arg("text/html");
+
         self.invoke_command_with_timeout(
-            Command::new("wl-copy").arg("--type").arg("text/html"),
+            command,
             Some(html.as_bytes()),
-            "wl-copy",
-        ).map(|_| ())
+            None,
+            ClipboardAction::Set,
+        )
     }
 }
 
 impl WaylandFallbackClipboard {
     fn invoke_command_with_timeout(
         &self,
-        mut command: &mut Command,
-        // IDEA: (input_data, output_data): (Option<&[u8]>, Option<&mut String>) 🤔
-        // BUT then we no longer need the output in Result 🤔
-        // .. OR DO SOMETHING ELSE ENTIRELY 🤔
+        mut command: Command,
         input_data: Option<&[u8]>,
-        name: &str,
-    ) -> Result<String> {
+        output_buffer: Option<&mut String>,
+        action: ClipboardAction,
+    ) -> Result<()> {
         let timeout = std::time::Duration::from_millis(self.command_timeout);
 
         if input_data.is_some() {
-            command = command.stdin(Stdio::piped());
-        } else {
-            command = command.stdout(Stdio::piped());
+            command.stdin(Stdio::piped());
         }
 
-        match command.spawn() {
-            Ok(mut child) => {
-                if let Some(data) = input_data {
-                    let stdin = child.stdin.as_mut().ok_or_else(|| anyhow::anyhow!("Unable to open stdin"))?;
-                    stdin.write_all(data)?;
+        if output_buffer.is_some() {
+            command.stdout(Stdio::piped());
+        }
+
+        let name = command.get_program().to_string_lossy().into_owned();
+
+        // Spawn the command upfront so we can stream input or capture output as needed
+        let mut child = command.spawn().map_err(|err| {
+            error!("could not invoke '{name}': {err}");
+            action.into_error()
+        })?;
+
+        // Provide stdin payload if any
+        if let Some(data) = input_data {
+            let stdin = child
+                .stdin
+                .as_mut()
+                .ok_or_else(|| anyhow::anyhow!("Unable to open stdin"))?;
+            stdin.write_all(data)?;
+        }
+
+        // Monitor the child with a timeout
+        match child.wait_timeout(timeout) {
+            Ok(Some(status)) if status.success() => {}
+            Ok(Some(_)) => {
+                error!("error, {name} exited with non-zero exit code");
+                let _ = child.wait();
+                return Err(action.into_error().into());
+            }
+            Ok(None) => {
+                error!("error, {name} has timed-out, killing the process");
+                if child.kill().is_err() {
+                    error!("unable to kill {name}");
                 }
-                match child.wait_timeout(timeout) {
-                    Ok(status_code) => {
-                        if let Some(status) = status_code {
-                            if status.success() {
-                                // TODO: check if output expected
-                                if let Some(mut io) = child.stdout {
-                                    let mut output = Vec::new();
-                                    io.read_to_end(&mut output)?;
-                                    Ok(String::from_utf8_lossy(&output).to_string())
-                                } else {
-                                    Ok(String::new())
-                                }
-                            } else {
-                                error!("error, {} exited with non-zero exit code", name);
-                                Err(WaylandFallbackClipboardError::SetOperationFailed().into())
-                            }
-                        } else {
-                            error!("error, {} has timed-out, killing the process", name);
-                            if child.kill().is_err() {
-                                error!("unable to kill {}", name);
-                            }
-                            // FIXME: might not be a 'Set' operation that failed anymore 🤔
-                            Err(WaylandFallbackClipboardError::SetOperationFailed().into())
-                        }
-                    }
-                    Err(err) => {
-                        error!("error while executing '{}': {}", name, err);
-                        Err(WaylandFallbackClipboardError::SetOperationFailed().into())
-                    }
-                }
+                let _ = child.wait();
+                return Err(action.into_error().into());
             }
             Err(err) => {
-                error!("could not invoke '{}': {}", name, err);
-                Err(WaylandFallbackClipboardError::SetOperationFailed().into())
+                error!("error while executing '{name}': {err}");
+                if child.kill().is_err() {
+                    error!("unable to kill {name}");
+                }
+                let _ = child.wait();
+                return Err(action.into_error().into());
             }
+        }
+
+        // Command exited successfully, collect stdout if needed
+        if let Some(buffer) = output_buffer {
+            let mut stdout = child.stdout.take().ok_or_else(|| {
+                error!("stdout not available for '{name}'");
+                action.into_error()
+            })?;
+            buffer.clear();
+            stdout.read_to_string(buffer)?;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Copy, Clone, Eq, PartialEq)]
+enum ClipboardAction {
+    Get,
+    Set,
+}
+
+impl ClipboardAction {
+    fn into_error(self) -> WaylandFallbackClipboardError {
+        match self {
+            ClipboardAction::Get => WaylandFallbackClipboardError::GetOperationFailed(),
+            ClipboardAction::Set => WaylandFallbackClipboardError::SetOperationFailed(),
         }
     }
 }
@@ -211,6 +254,9 @@ pub(crate) enum WaylandFallbackClipboardError {
 
     #[error("clipboard set operation failed")]
     SetOperationFailed(),
+
+    #[error("clipboard get operation failed")]
+    GetOperationFailed(),
 
     #[error("image not found: `{0}`")]
     ImageNotFound(PathBuf),

--- a/espanso/src/cli/worker/engine/dispatch/executor/clipboard_injector.rs
+++ b/espanso/src/cli/worker/engine/dispatch/executor/clipboard_injector.rs
@@ -191,6 +191,7 @@ impl<'a> ClipboardRestoreGuard<'a> {
         restore_delay: u64,
         clipboard_operation_options: ClipboardOperationOptions,
     ) -> Self {
+        // note: `get_text` called here, to restore the clipboard later on
         let clipboard_content = clipboard.get_text(&clipboard_operation_options);
 
         Self {
@@ -209,6 +210,7 @@ impl Drop for ClipboardRestoreGuard<'_> {
             // A delay is needed to mitigate the problem
             std::thread::sleep(std::time::Duration::from_millis(self.restore_delay));
 
+            // note: `set_text` called here to restore the clipboard
             if let Err(error) = self
                 .clipboard
                 .set_text(&content, &self.clipboard_operation_options)


### PR DESCRIPTION
Hello!

(note: this was fully Human-made, zero AI involved)

> [!NOTE]
> Edit: Skimming GH issues mentioning `Wayland`, I think this PR could fix the following issues:
> #2428 #2162 #2270 #2497 #2582 #1670 #2340 #901 #1367
> (maybe more, to be confirmed)



### Context

Since I had to switch to Wayland a few months ago, I've always had trouble with Espanso and attributed it to some weirdness around Wayland, protocol instabilities, KDE Plasma6.. (and the missing capability on NixOS)

For example some expansions would work in Firefox but not all, and almost no expansions would work in Wezterm (the trigger is removed but the replacement is not pasted).
Other times it would simply paste the wrong clipboard data, as if Espanso didn't set the clipboard at all.
And when I had something like `foo` in my clipboard, tried an expansion that failed, I couldn't paste the original `foo` that was supposed to be restored by Espanso after the expansion.

Since latest NixOS 25.11 release, the capability issue was fully resolved and I was still having these weird issues..
The first day of 2026 motivated me to dive in and actually fix this! 😀


### Findings

With `WAYLAND_DEBUG=1` and some additional debug logs I've found that the MIME type of the copied text is set correctly then immediately overwritten to a bad type:
```
...
[ 442709.543] {Default Queue}  -> wl_data_device_manager#7.get_data_device(new id wl_data_device#3, wl_seat#6)
[ 442741.732] {Default Queue}  -> wl_data_device_manager#7.create_data_source(new id wl_data_source#11)
...

!! NOTE: The clipboard is set here
[ 442747.844] {Default Queue}  -> wl_data_device#3.set_selection(wl_data_source#11, 35716)

!! NOTE: The data type is set correctly here (`offer` line)
[ 442747.880] {Default Queue} wl_data_device#3.data_offer(new id wl_data_offer#4278190080)
[ 442747.891] {Default Queue} wl_data_offer#4278190080.offer("text/plain;charset=utf-8")   // <- here
[ 442747.900] {Default Queue} wl_data_device#3.selection(wl_data_offer#4278190080)
...

!! BAD: The data type is ~immediately overwritten to a bad type
[ 442748.373] {Default Queue} wl_data_device#3.data_offer(new id wl_data_offer#4278190081)
[ 442748.383] {Default Queue} wl_data_offer#4278190081.offer("l�4��U")   // <- here
[ 442748.390] {Default Queue} wl_data_device#3.selection(wl_data_offer#4278190081)
...
```
And this weird MIME type was also used when restoring the original clipboard content, easy to validate with `wl-paste --list-types`.

In Wezterm, I've found that only selection with MIME type `text/plain;charset=utf-8` can be pasted, so the weird `l�4��U` type doesn't cut it and nothing can be pasted after Espanso changed the clipboard.

It probably worked better in Firefox because the browser have a lot more flexibility on the kind of data that can be pasted, potentially doing its own detection.


### The fix

I'm not exactly sure why the MIME type was immediately overwritten after being correct for less than a second.
I tried to disable Klipper (KDE's clipboard manager) which might have caused this but I still had the same issue.
👉 Anyway, manually setting the MIME type fixes everything for me, and all my expansions work everywhere.

### Thoughts

The clipboard restoration might need a better impl, to actually restore the original MIME type instead of forcing plain text. I'd prefer to do this in a separate PR though.

Also is there a reason the `wl-clipboard` crate isn't used, instead of calling `wl-copy` & `wl-paste` cli?
(using the cli is probably easier to do / think about 👀)