### PR TITLE
Add 'Code - Insiders.exe' to VSCode Windows patch

### DIFF
--- a/espanso/src/patch/patches/win/vscode_win.rs
+++ b/espanso/src/patch/patches/win/vscode_win.rs
@@ -28,7 +28,11 @@ pub fn patch() -> PatchDefinition {
     PatchDefinition {
         name: module_path!().split(':').next_back().unwrap_or("unknown"),
         is_enabled: || cfg!(target_os = "windows"),
-        should_patch: |app| app.exec.unwrap_or_default().contains("Code.exe"),
+        should_patch: |app| {
+            app.exec.is_some_and(|exec| {
+                exec.contains("Code.exe") || exec.contains("Code - Insiders.exe")
+            })
+        },
         apply: |base, name| {
             Arc::new(PatchedConfig::patch(
                 base,


### PR DESCRIPTION
Espanso doesn't work correctly out-of-the-box with VSCode [Insiders edition](https://code.visualstudio.com/insiders) (nightly channel), which uses a different executable filename - `Code - Insiders.exe`. I added it to the built-in patch, so that it works out-of-the-box as well.

## Additional info

`#pdetect#` output:

```yml
title: '● #pdetect • Untitled-1 - espanso - Visual Studio Code - Insiders'
exec: 'E:\Programs\Microsoft VS Code Insiders\Code - Insiders.exe'
class: ''
```

The workaround I've been using is a config like this (`.espanso/config/vscode.yml`):

```yml
filter_exec: "Code( - Insiders)?.exe"
backend: clipboard
key_delay: 10
```
