### PR TITLE
fix(search/macos): don't consume Return during IME composition on macOS

### DIFF
--- a/espanso-modulo/build.rs
+++ b/espanso-modulo/build.rs
@@ -292,7 +292,8 @@ fn build_native() {
         .file("src/sys/textview/textview_gui.cpp")
         .file("src/sys/troubleshooting/troubleshooting.cpp")
         .file("src/sys/troubleshooting/troubleshooting_gui.cpp")
-        .file("src/sys/common/mac.mm");
+        .file("src/sys/common/mac.mm")
+        .file("src/sys/search/search_mac.mm");
     build.flag("-std=c++17");
 
     for flag in cpp_flags {

--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -31,6 +31,13 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef __WXOSX__
+// Implemented in search_mac.mm. Returns true if the key window's first
+// responder currently has marked (uncommitted) text from an IME
+// composition (e.g. selecting a CJK candidate).
+extern bool IsImeComposingInKeyWindow();
+#endif
+
 // Platform-specific styles
 #ifdef __WXMSW__
 const int SEARCH_BAR_FONT_SIZE = 16;
@@ -307,6 +314,16 @@ void SearchFrame::OnCharEvent(wxKeyEvent &event) {
     } else if (event.GetKeyCode() == 'P' && event.RawControlDown()) {
         SelectPrevious();
     } else if (event.GetKeyCode() == WXK_RETURN || event.GetKeyCode() == WXK_NUMPAD_ENTER) {
+#ifdef __WXOSX__
+        // Don't consume Enter while an IME composition is in progress —
+        // the user is committing a candidate (e.g. selecting a Chinese
+        // character), not confirming the highlighted match. Let the event
+        // propagate so the IME can finalize its selection.
+        if (IsImeComposingInKeyWindow()) {
+            event.Skip();
+            return;
+        }
+#endif
         Submit();
     } else {
         event.Skip();

--- a/espanso-modulo/src/sys/search/search_mac.mm
+++ b/espanso-modulo/src/sys/search/search_mac.mm
@@ -1,0 +1,55 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2026 Federico Terzi and the espanso contributors
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+#import <AppKit/AppKit.h>
+
+// Reports whether the key window's first responder currently has marked
+// (uncommitted) text — i.e. an IME composition is in progress.
+//
+// macOS NSTextField uses a shared field editor (an NSTextView) for editing,
+// so when the user is typing into the search bar the firstResponder is
+// usually that field editor rather than the NSTextField itself.
+//
+// We check NSTextView directly first, fall back to NSTextField's
+// currentEditor, and finally to any responder conforming to
+// NSTextInputClient. Returns false on any unexpected state.
+bool IsImeComposingInKeyWindow() {
+    NSWindow *keyWindow = [NSApp keyWindow];
+    if (!keyWindow) {
+        return false;
+    }
+    NSResponder *responder = [keyWindow firstResponder];
+    if (!responder) {
+        return false;
+    }
+
+    if ([responder isKindOfClass:[NSTextView class]]) {
+        return [(NSTextView *)responder hasMarkedText];
+    }
+    if ([responder isKindOfClass:[NSTextField class]]) {
+        NSText *editor = [(NSTextField *)responder currentEditor];
+        if ([editor isKindOfClass:[NSTextView class]]) {
+            return [(NSTextView *)editor hasMarkedText];
+        }
+    }
+    if ([responder conformsToProtocol:@protocol(NSTextInputClient)]) {
+        return [(id<NSTextInputClient>)responder hasMarkedText];
+    }
+    return false;
+}


### PR DESCRIPTION
## Summary

- Stops the search bar from consuming `Return` while an IME composition is in progress on macOS.
- Lets CJK users (Chinese / Japanese / Korean) press `Return` to land **whatever the IME is currently holding** — typically the raw Latin letters they just typed (e.g. `lee`, `ka`, `gye`) — into the search field, instead of triggering whichever match happens to be highlighted.
- Fixes #2687.


## Demo

Both videos captured on macOS Tahoe 26 (Apple Silicon, Apple Pinyin IME, ~130 user-defined snippets).

### Before (espanso 2.3.0, brew cask)

Typing the pinyin `Poin` under a CJK IME and pressing `Return` to commit `Point` to the search field — instead, espanso fires `Submit()` immediately, picking whichever match is currently highlighted (the first item `01trie`, since the search field is still empty because the IME never got to commit). The wrong snippet then expands into vim:

![BUG: wrong snippet 01trie expands under CJK IME](https://raw.githubusercontent.com/znzryb/espanso/media-demos/espanso_ime_bug_demo.gif)

### After (this PR, built from `znzryb/espanso fix/search-bar-ime-enter-cjk`)

Same exact keystrokes — first `Return` now lets the IME commit `Point` into the search field, the matches re-filter, and the second `Return` expands the intended `Point` class snippet into vim:

![FIX: same keystrokes, IME commits then snippet expands correctly](https://raw.githubusercontent.com/znzryb/espanso/media-demos/espanso_ime_fix_demo.gif)

## Why this matters

Today `SearchFrame::OnCharEvent` unconditionally calls `Submit()` on `WXK_RETURN` / `WXK_NUMPAD_ENTER`. To understand why that's a hard blocker under a CJK IME, it helps to spell out how those IMEs work:

When a CJK IME is active, the keys you press do **not** go straight into the focused text field. They first land in the IME's own preedit buffer and are shown as underlined "marked text" inside the field. The user then has to actively tell the IME how to commit that buffer:

- **`Space`** → convert to Chinese / kana candidates and pick the first one.
- **`1` / `2` / `3` / …** → pick a numbered candidate.
- **`Return`** → commit the **raw Latin letters as-is** (e.g. `lee` lands as the three ASCII characters `l`, `e`, `e`, not as `李`/`累`/etc.). This is the only path that gets *any* text into the field if the user doesn't want IME conversion.

So `Return` here isn't an "optional submit shortcut" — it's the only way to land **even ASCII letters** into the search bar while a CJK IME layout is active. Espanso swallowing `Return` therefore has two failure modes stacked on top of each other:

1. The search bar expands whatever match is highlighted at the moment the user is just trying to land a character (Chinese, kana, or even plain ASCII).
2. Because `Return` never reaches the IME, **no text at all — Chinese, kana, or raw Latin — can be typed into the search field** while a CJK IME layout is the active one.

This makes the search bar effectively unusable for CJK users without first toggling the IME off to a plain US layout.

## Approach

- New `espanso-modulo/src/sys/search/search_mac.mm` exposes `IsImeComposingInKeyWindow()`, which asks the key window's first responder whether it has marked text via `NSTextInputClient.hasMarkedText`. NSTextField uses a shared field editor (an NSTextView), so the helper checks the responder directly, then falls back to `currentEditor`, then to the `NSTextInputClient` protocol.
- The `Return` branch in `OnCharEvent` consults this on macOS before calling `Submit()`. If a composition is in progress, the event is passed through (`event.Skip()`) so the IME can finalize whatever it's holding (raw Latin letters or a converted candidate); otherwise the existing submit behavior is preserved.
- `build.rs` is updated to compile the new `.mm` alongside the existing `src/sys/common/mac.mm`.
- Windows and Linux code paths are untouched (guarded by `#ifdef __WXOSX__`). The same class of bug exists there but needs different APIs (IMM on Windows, IBus/preedit on Linux) — left as platform-specific follow-up.

This is the search-bar-UI counterpart of #1968, which is the same class of problem in the trigger engine.

## Testing

Built and tested locally on macOS Tahoe 26 (Darwin 25.2.0), Apple Silicon:

- **CJK path**: open search bar with `ALT+SPACE` while macOS Pinyin IME is active → type `lee` → `Return` lands `lee` (Latin literal) in the search field instead of triggering the highlight → matches re-filter on the new query → second `Return` (no marked text) submits the highlighted match into the target app, as before.
- **Non-IME path**: with a plain US keyboard layout, `Return` still immediately submits the highlighted match. No behavior change vs. `dev`.
- Verified end-to-end against `~/Library/Application Support/espanso/` with ~130 user-defined matches; expansion into the target app works correctly after a CJK-IME-mediated search session.

## Follow-ups (intentionally out of scope)

- Windows / Linux: same class of bug, different APIs. Happy to take a follow-up PR if a maintainer wants to scope it.
- Trigger engine path (#1968): the underlying composition-detection helper is general; if maintainers prefer, it could be hoisted out of `search/` and reused on the trigger detection side.

## Test plan

- [x] macOS Pinyin IME + search bar: `Return` lands Latin literal in field, doesn't fire highlight
- [x] macOS no-IME (US layout): `Return` still submits highlight (no regression)
- [x] End-to-end: search → CJK-IME-mediated query → snippet expansion into target app
- [ ] Windows / Linux: not modified, not tested (out of scope)


