### PR TITLE
ci: distribute macOS build as DMG instead of ZIP

### DIFF
--- a/.github/workflows/create-release-draft.yml
+++ b/.github/workflows/create-release-draft.yml
@@ -264,15 +264,13 @@ jobs:
             --no-default-features \
             --features native-tls,modulo
           bash ./scripts/create_bundle.sh
-      - name: Create ZIP archive
+      - name: Create DMG archive
         run: |
-          ditto -c -k --sequesterRsrc --keepParent target/mac/Espanso.app Espanso-Mac-Universal.zip
+          hdiutil create -volname "Espanso" \
+            -srcfolder target/mac/Espanso.app \
+            -ov -format UDZO \
+            Espanso-Mac-Universal.dmg
 
-      # This doesn't work:
-      #
-      # - name: Upload artifacts to Github Releases
-      #   run: |
-      #     gh release upload ${{ needs.extract-version.outputs.espanso_version }} Espanso-Mac-Universal.zip
-      #
-      # The problem with this is that it's not signed, only ziiped into `Espanso-Mac-Universal.zip`
-      # so when you try to install it, macOS refuses to excecute from the Applications folder
+      - name: Upload artifacts to Github Releases
+        run: |
+          gh release upload ${{ needs.extract-version.outputs.espanso_version }} Espanso-Mac-Universal.dmg


### PR DESCRIPTION
## Summary

Changes the macOS release artifact from a ZIP-wrapped DMG to a plain DMG file.

## Problem

Currently the macOS build creates a ZIP archive of the .app bundle, but macOS users expect a DMG for app distribution. The ZIP wrapping is unnecessary and non-standard.

## Solution

- Replace `ditto -c -k` (ZIP) with `hdiutil create` (DMG) in the release workflow
- Enable the upload step that was previously commented out

## Changes

`.github/workflows/create-release-draft.yml`:
- Create DMG using `hdiutil create -format UDZO` (compressed DMG)
- Upload DMG directly to GitHub Releases

Fixes #2624