### PR TITLE
nix: Update nixpkgs; fix evaluation warnings

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -4,3 +4,4 @@ if ! command -v nix > /dev/null; then
 fi
 
 use flake
+watch_file ./nix/espanso.nix

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1779508470,
-        "narHash": "sha256-Ap9KJX+5xHIn3bPIpfNgT6MEXdAECECwo4/rmlQD74M=",
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "29916453413845e54a65b8a1cf996842300cd299",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,7 @@
       in
       {
         checks.espanso = self.packages.${system}.espanso.override { buildType = "debug"; };
-        formatter = pkgs.nixfmt-rfc-style;
+        formatter = pkgs.nixfmt;
         packages = {
           espanso = pkgs.callPackage ./nix/espanso.nix { };
           default = self.packages.${system}.espanso;
@@ -54,7 +54,7 @@
                   clang-tools
                   rustfmt
                 ]
-                ++ lib.optional (stdenv.isx86_64 && stdenv.isLinux) [ cargo-tarpaulin ];
+                ++ lib.optionals (stdenv.isx86_64 && stdenv.isLinux) [ cargo-tarpaulin ];
               shellHook = ''
                 export RUST_BACKTRACE="1"
                 export RUSTFLAGS="''${RUSTFLAGS:-""} ${commonRustFlagsEnv}";

--- a/nix/espanso.nix
+++ b/nix/espanso.nix
@@ -7,16 +7,16 @@
   libpng,
   libX11,
   libXi,
+  libxcb,
   libxkbcommon,
   libXtst,
   openssl,
   pkg-config,
   setxkbmap,
   wl-clipboard,
-  wxGTK32,
+  wxwidgets_3_2,
   xclip,
   xdotool,
-  xorg,
   waylandSupport ? false,
   buildType ? "release",
 }:
@@ -45,7 +45,7 @@ rustPlatform.buildRustPackage {
 
   buildInputs = [
     libpng
-    wxGTK32
+    wxwidgets_3_2
   ]
   ++ lib.optionals stdenv.hostPlatform.isLinux [
     dbus
@@ -57,7 +57,7 @@ rustPlatform.buildRustPackage {
     wl-clipboard
   ]
   ++ lib.optionals x11Support [
-    xorg.libxcb.dev
+    libxcb.dev
     libX11
     libXi
     libXtst
@@ -66,7 +66,7 @@ rustPlatform.buildRustPackage {
   ];
   nativeBuildInputs = [
     pkg-config
-    wxGTK32
+    wxwidgets_3_2
   ];
 
   inherit buildType;


### PR DESCRIPTION
Hello ;)

Fixed evaluation warnings:
- The xorg package set has been deprecated, 'xorg.libxcb' has been renamed to 'libxcb'
- 'wxGTK32' has been renamed to 'wxwidgets_3_2'
- Dependency of package 'espanso' uses a nested list in attribute 'nativeBuildInputs'. This is deprecated as of Nixpkgs release 26.05, and support will be removed in a future nixpkgs release.