### PR TITLE
fix(daemon): respawn worker on unexpected exit instead of hanging or quitting

### DIFF
--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -32,7 +32,7 @@ use crate::{
     common_flags::*,
     exit_code::{
         DAEMON_ALREADY_RUNNING, DAEMON_FATAL_CONFIG_ERROR, DAEMON_GENERAL_ERROR, DAEMON_SUCCESS,
-        WORKER_ERROR_EXIT_NO_CODE, WORKER_EXIT_ALL_PROCESSES, WORKER_RESTART, WORKER_SUCCESS,
+        WORKER_ERROR_EXIT_NO_CODE, WORKER_EXIT_ALL_PROCESSES, WORKER_RESTART,
     },
     ipc::{create_ipc_client_to_worker, IPCEvent},
     lock::{acquire_daemon_lock, acquire_worker_lock},
@@ -45,6 +45,15 @@ mod ipc;
 mod keyboard_layout_watcher;
 mod troubleshoot;
 mod watcher;
+
+/// Maximum number of times the daemon will automatically respawn a worker that
+/// keeps dying in quick succession before giving up, to avoid a tight
+/// crash-loop (e.g. when the worker can't start due to missing permissions).
+const MAX_WORKER_AUTO_RESTARTS: u32 = 5;
+
+/// If a worker stays alive at least this long before dying, it is considered to
+/// have run successfully and the auto-restart counter is reset.
+const WORKER_HEALTHY_RUNTIME: std::time::Duration = std::time::Duration::from_secs(60);
 
 pub fn new() -> CliModule {
     #[allow(clippy::needless_update)]
@@ -129,6 +138,16 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
     ipc::initialize_and_spawn(&paths.runtime, exit_notify.clone())
         .expect("unable to initialize ipc server for daemon");
 
+    // Bookkeeping for automatic worker respawn (see issue #2530).
+    // `last_worker_spawn` tracks how long the current worker has been alive, so
+    // a healthy worker resets the crash-loop counter. `worker_auto_restart_count`
+    // counts consecutive rapid respawns. `expected_worker_exits` counts worker
+    // exits the daemon initiated itself (during a restart) and must therefore
+    // NOT be treated as unexpected deaths.
+    let mut last_worker_spawn = Instant::now();
+    let mut worker_auto_restart_count: u32 = 0;
+    let mut expected_worker_exits: u32 = 0;
+
     loop {
         select! {
           recv(watcher_signal) -> _ => {
@@ -156,13 +175,23 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
               }
             };
 
-            if should_restart_worker {
-              restart_worker(&paths, &paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_CONFIG_CHANGED.to_string()));
+            if should_restart_worker
+              && restart_worker(&paths, &paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_CONFIG_CHANGED.to_string()))
+            {
+              // We deliberately terminated the previous worker and spawned a
+              // replacement; expect (and ignore) the old worker's exit.
+              expected_worker_exits += 1;
+              last_worker_spawn = Instant::now();
+              worker_auto_restart_count = 0;
             }
           }
           recv(keyboard_layout_watcher_signal) -> _ => {
             info!("keyboard layout change detected, restarting worker...");
-            restart_worker(&paths, &paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_KEYBOARD_LAYOUT_CHANGED.to_string()));
+            if restart_worker(&paths, &paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_KEYBOARD_LAYOUT_CHANGED.to_string())) {
+              expected_worker_exits += 1;
+              last_worker_spawn = Instant::now();
+              worker_auto_restart_count = 0;
+            }
           }
           recv(exit_signal) -> code => {
             match code {
@@ -175,10 +204,38 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
                   WORKER_RESTART => {
                     info!("worker requested a restart, spawning a new one...");
                     spawn_worker(&paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_MANUAL.to_string()));
+                    last_worker_spawn = Instant::now();
+                    worker_auto_restart_count = 0;
                   }
                   _ => {
-                    error!("received unexpected exit code from worker {code}, exiting");
-                    return code;
+                    if expected_worker_exits > 0 {
+                      // This exit was triggered by a restart we initiated; the
+                      // replacement worker has already been spawned.
+                      expected_worker_exits -= 1;
+                      continue;
+                    }
+
+                    warn!("worker exited unexpectedly with code {code}");
+
+                    // Reset the crash-loop counter if the worker had been
+                    // running for a healthy amount of time before dying.
+                    if last_worker_spawn.elapsed() >= WORKER_HEALTHY_RUNTIME {
+                      worker_auto_restart_count = 0;
+                    }
+
+                    if worker_auto_restart_count >= MAX_WORKER_AUTO_RESTARTS {
+                      error!("worker died {worker_auto_restart_count} times in quick succession; giving up to avoid a crash-loop");
+                      return code;
+                    }
+
+                    worker_auto_restart_count += 1;
+                    let backoff =
+                      std::time::Duration::from_millis(500 * u64::from(worker_auto_restart_count));
+                    warn!("respawning worker (attempt {worker_auto_restart_count}/{MAX_WORKER_AUTO_RESTARTS}) after {backoff:?}");
+                    std::thread::sleep(backoff);
+
+                    spawn_worker(&paths_overrides, exit_notify.clone(), Some(WORKER_START_REASON_MANUAL.to_string()));
+                    last_worker_spawn = Instant::now();
                   }
                 }
               },
@@ -250,24 +307,29 @@ fn spawn_worker(
 
     let mut child = command.spawn().expect("unable to spawn worker process");
 
-    // Create a monitor thread that will exit with the same non-zero code if
-    // the worker thread exits
+    // Create a monitor thread that forwards the worker's exit code to the
+    // daemon when the worker process terminates. The daemon uses this to decide
+    // whether to shut down, restart, or respawn the worker.
+    //
+    // IMPORTANT: forward *every* exit, including a successful exit
+    // (WORKER_SUCCESS) and the case where the exit status can't be obtained.
+    // Previously a WORKER_SUCCESS exit (and a failed `wait()`) was dropped
+    // silently, which left the daemon blocked in its `select!` loop with a dead
+    // worker that was never respawned (the "half-dead" state). See issue #2530.
     std::thread::Builder::new()
         .name("worker-status-monitor".to_string())
-        .spawn(move || {
-            let result = child.wait();
-            if let Ok(status) = result {
-                if let Some(code) = status.code() {
-                    if code != WORKER_SUCCESS {
-                        exit_notify
-                            .send(code)
-                            .expect("unable to forward worker exit code");
-                    }
-                } else {
-                    exit_notify
-                        .send(WORKER_ERROR_EXIT_NO_CODE)
-                        .expect("unable to forward worker exit code");
-                }
+        .spawn(move || match child.wait() {
+            Ok(status) => {
+                let code = status.code().unwrap_or(WORKER_ERROR_EXIT_NO_CODE);
+                exit_notify
+                    .send(code)
+                    .expect("unable to forward worker exit code");
+            }
+            Err(err) => {
+                error!("unable to wait for worker process: {err}");
+                exit_notify
+                    .send(WORKER_ERROR_EXIT_NO_CODE)
+                    .expect("unable to forward worker exit code");
             }
         })
         .expect("Unable to spawn worker monitor thread");
@@ -278,7 +340,7 @@ fn restart_worker(
     paths_overrides: &PathsOverrides,
     exit_notify: Sender<i32>,
     start_reason: Option<String>,
-) {
+) -> bool {
     match create_ipc_client_to_worker(&paths.runtime) {
         Ok(mut worker_ipc) => {
             if let Err(err) = worker_ipc.send_async(IPCEvent::Exit) {
@@ -305,7 +367,9 @@ fn restart_worker(
 
     if has_timed_out {
         error!("could not restart worker, as the exit process has timed out");
+        false
     } else {
         spawn_worker(paths_overrides, exit_notify, start_reason);
+        true
     }
 }


### PR DESCRIPTION
## Problem

On macOS (service mode), espanso can silently stop expanding for hours: the `daemon` process stays alive while the `worker` process is gone and is never respawned. `espanso service status` reports "not running" even though the daemon PID is alive, and a manual `espanso restart` is required to recover. Reported in #2530 (the dead-worker symptom also appears in #2576).

## Root cause

In `espanso/src/cli/daemon/mod.rs`:

1. `spawn_worker()`'s `worker-status-monitor` thread only forwarded an exit code to the daemon when the worker exited **non-zero** (or died by signal → `WORKER_ERROR_EXIT_NO_CODE`). A worker that exited `WORKER_SUCCESS` (0) unexpectedly — or a failed `child.wait()` — was dropped silently, so the daemon's `select!` loop was never notified and the worker was never respawned (the "half-dead" state).
2. In the `exit_signal` arm, any code other than `WORKER_EXIT_ALL_PROCESSES` / `WORKER_RESTART` hit `_ => { ...; return code; }`, so an *unexpected* worker death made the daemon **exit**. Combined with the macOS launchd plist having `RunAtLoad` but no `KeepAlive`, nothing relaunched espanso.

## Fix

- Forward **every** worker exit to the daemon (including `WORKER_SUCCESS` and the `wait()` error case), so the daemon is always notified.
- On an **unexpected** worker exit, respawn the worker with bounded, backing-off retries (`MAX_WORKER_AUTO_RESTARTS`), giving up only if it dies repeatedly in quick succession (crash-loop protection; the counter resets after a healthy run of `WORKER_HEALTHY_RUNTIME`).
- Track daemon-initiated restarts (config / keyboard-layout change) via an `expected_worker_exits` counter so the deliberately-terminated old worker is not mistaken for an unexpected death and double-spawned. `restart_worker` now returns whether it actually spawned a replacement.

## Testing

Built with `--no-default-features --features vendored-tls`; clippy clean on the changed file. Manual test on macOS with isolated config/runtime dirs:

- **Kill the worker** → daemon logs `worker exited unexpectedly with code 90` then `respawning worker (attempt 1/5) after 500ms`; a new worker starts. (Before this change: the daemon hung with no worker.)
- **Repeated rapid kills** → backoff `500ms → 1s → 1.5s → 2s → 2.5s`, then `worker died 5 times in quick succession; giving up to avoid a crash-loop` and the daemon exits cleanly (no infinite spin).
- **Normal config-change restart** still works without double-spawning (expected-exit accounting).

## Note / open question

This makes the daemon resilient to worker death regardless of cause. On macOS the trigger appears to be the worker being torn down across sleep / secure-input transitions (see #2530). Separately, the macOS launchd plist lacks `KeepAlive`; I deliberately left that out of this PR because the launchd-managed process is the short-lived `launcher`, so adding `KeepAlive` naively would cause a respawn loop — happy to address it properly in a follow-up if maintainers prefer.
