### PR TITLE
remove multilingual key

### DIFF
--- a/docs/book.toml
+++ b/docs/book.toml
@@ -1,7 +1,6 @@
 [book]
 authors = ["Auca Coyan"]
 language = "en"
-multilingual = false
 src = "src"
 title = "espanso-docs"
 


### PR DESCRIPTION
this breaks mdBook from building:

```console
ERROR Invalid configuration file
        Caused by: TOML parse error at line 4, column 1
  |
4 | multilingual = false
  | ^^^^^^^^^^^^
```