### PR TITLE
protect dev branch from commits in vs code

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,5 +4,6 @@
   },
   "[jsonc]": {
     "editor.defaultFormatter": "biomejs.biome"
-  }
+  },
+  "git.branchProtection": ["dev"]
 }


### PR DESCRIPTION
just inside vs code:
```json
  "git.branchProtection": ["dev"]
```
blocks you from commiting the dev branch, just in case you forgot it's the default branch