### PR TITLE
make clippy check only our deps

### DIFF
--- a/.github/workflows/ci-arm.yml
+++ b/.github/workflows/ci-arm.yml
@@ -1,7 +1,7 @@
 name: ARM CI
 
 on:
-    workflow_dispatch:
+  workflow_dispatch:
 
 defaults:
   run:
@@ -50,7 +50,7 @@ jobs:
             --no-default-features \
             --features vendored-tls
       - name: Clippy
-        run: cargo clippy --all-targets --features=modulo,vendored-tls -- --deny warnings
+        run: cargo clippy --all-targets --features=modulo,vendored-tls -- --deny warnings --no-deps
       # - uses: cachix/install-nix-action@v31
       #   - name: nix fmt
       #     run: nix fmt -- --check **/*.nix
@@ -75,4 +75,3 @@ jobs:
           cargo build
       - name: Clippy
         run: cargo clippy -- --deny warnings
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
             --no-default-features \
             --features vendored-tls
       - name: Clippy
-        run: cargo clippy --all-targets --features=modulo,vendored-tls -- --deny warnings
+        run: cargo clippy --all-targets --features=modulo,vendored-tls -- --deny warnings --no-deps
       - uses: cachix/install-nix-action@v31
       - name: nix fmt
         run: nix fmt -- --check **/*.nix
@@ -114,7 +114,7 @@ jobs:
             --no-default-features \
             --features vendored-tls,wayland
       - name: Clippy
-        run: cargo clippy --features=modulo,vendored-tls,wayland -- --deny warnings
+        run: cargo clippy --features=modulo,vendored-tls,wayland -- --deny warnings --no-deps --no-deps
       # leaving this nix because is quite fast. macOS in the other hand takes
       # an hour to complete
       - uses: cachix/install-nix-action@v31
@@ -143,8 +143,8 @@ jobs:
         run: cargo test --workspace
       - name: Clippy
         run: |
-          cargo clippy --target=aarch64-apple-darwin -- --deny warnings
-          cargo clippy --target=x86_64-apple-darwin -- --deny warnings
+          cargo clippy --target=aarch64-apple-darwin -- --deny warnings --no-deps
+          cargo clippy --target=x86_64-apple-darwin -- --deny warnings --no-deps
 
   windows:
     runs-on: windows-latest
@@ -163,4 +163,4 @@ jobs:
         run: |
           cargo build
       - name: Clippy
-        run: cargo clippy -- --deny warnings
+        run: cargo clippy -- --deny warnings --no-deps


### PR DESCRIPTION
In order to make the CI faster, I believe if we can make clippy check only our deps (`espanso-*`) it can significantly reduce the time