### PR TITLE
feat(wayland): detect active window on KDE natively via KWin D-Bus sc…

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1044,7 +1044,9 @@ dependencies = [
  "cc",
  "espanso-package",
  "log",
+ "serde_json",
  "widestring",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,6 +71,7 @@ tempdir = "0.3.7"
 thiserror = "1.0.23"
 walkdir = "2.3.1"
 widestring = "0.4.3"
+zbus = "5.9.0"
 windows = { version = "0.61.1", features = [
   "Win32_UI_WindowsAndMessaging",
   "Win32_System_Console",

--- a/espanso-info/Cargo.toml
+++ b/espanso-info/Cargo.toml
@@ -7,7 +7,7 @@ build = "build.rs"
 
 [features]
 # If the wayland feature is enabled, all X11 dependencies will be dropped
-wayland = []
+wayland = ["dep:zbus", "dep:serde_json"]
 
 [dependencies]
 log.workspace = true
@@ -19,6 +19,10 @@ workspace = true
 
 [target.'cfg(windows)'.dependencies]
 widestring.workspace = true
+
+[target.'cfg(target_os = "linux")'.dependencies]
+zbus = { workspace = true, optional = true }
+serde_json = { workspace = true, optional = true }
 
 [build-dependencies]
 cc.workspace = true

--- a/espanso-info/src/lib.rs
+++ b/espanso-info/src/lib.rs
@@ -85,16 +85,19 @@ pub fn get_provider() -> Result<Box<dyn AppInfoProvider>> {
                 return Ok(Box::new(wayland::WaylandNiriAppInfoProvider::new()));
             }
             "kde" => {
-                if Command::new("kdotool")
-                    .arg("getactivewindow")
-                    .arg("getwindowclassname")
-                    .output()
-                    .is_ok()
-                {
-                    info!("using WaylandKDEAppInfoProvider");
-                    return Ok(Box::new(wayland::WaylandKDEAppInfoProvider::new()));
+                if wayland::kde_dbus::is_kwin_available() {
+                    match wayland::WaylandKDEAppInfoProvider::new() {
+                        Ok(provider) => {
+                            info!("using WaylandKDEAppInfoProvider");
+                            return Ok(Box::new(provider));
+                        }
+                        Err(err) => {
+                            info!("could not initialize the KWin D-Bus connection: {err:?}");
+                        }
+                    }
+                } else {
+                    info!("KWin D-Bus service (org.kde.KWin) not available on the session bus.");
                 }
-                info!("kdotool missing or not available for the current wayland DE.");
             }
             "sway" | "hyprland" | "labwc" | "wayfire" | "budgie" => {
                 if Command::new("wlrctl")

--- a/espanso-info/src/wayland/kde_dbus.rs
+++ b/espanso-info/src/wayland/kde_dbus.rs
@@ -1,0 +1,257 @@
+/*
+ * This file is part of espanso.
+ *
+ * Copyright (C) 2019-2021 Federico Terzi
+ *
+ * espanso is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * espanso is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+//! Native D-Bus client for `KWin`'s scripting interface, used to query the
+//! active window on KDE Plasma (both Wayland and X11 sessions) without
+//! external tools.
+//!
+//! `KWin` has no direct "get active window" D-Bus method, but it can load and
+//! run scripts (`org.kde.KWin` service, `/Scripting` object). The loaded
+//! script runs inside the compositor, reads `workspace.activeWindow`, and
+//! reports back by *calling us over D-Bus* (`KWin`'s `callDBus()` JS function,
+//! addressed at this connection's unique bus name) — necessary because
+//! `org.kde.kwin.Script.run()` has no return value.
+//!
+//! Prior art: kdotool (<https://github.com/jinliu/kdotool>) uses the same
+//! `KWin` interface; this module replaces espanso's previous dependency on the
+//! kdotool binary.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use anyhow::{anyhow, bail, Context, Result};
+
+/// `KWin` JS executed inside the compositor. Placeholders: `{{dbus_addr}}` is
+/// our unique bus name (e.g. `:1.42`), `{{seq}}` a per-query sequence number
+/// used to discard stale replies from earlier timed-out queries.
+const KWIN_SCRIPT: &str = r#"
+function output_result(message) {
+    callDBus("{{dbus_addr}}", "/", "", "result", message.toString());
+}
+function output_error(message) {
+    callDBus("{{dbus_addr}}", "/", "", "error", message.toString());
+}
+var w = workspace.activeWindow;
+if (w == null) {
+    output_error("No active window");
+} else {
+    output_result(JSON.stringify({
+        seq: {{seq}},
+        title: w.caption,
+        class_name: w.resourceClass,
+        pid: w.pid
+    }));
+}
+"#;
+
+const KWIN_SERVICE: &str = "org.kde.KWin";
+const SCRIPTING_PATH: &str = "/Scripting";
+const SCRIPTING_INTERFACE: &str = "org.kde.kwin.Scripting";
+const SCRIPT_INTERFACE: &str = "org.kde.kwin.Script";
+const CALLBACK_TIMEOUT: Duration = Duration::from_secs(5);
+
+#[derive(Debug)]
+pub(crate) struct KdeWindowInfo {
+    pub title: Option<String>,
+    pub class_name: Option<String>,
+    pub pid: Option<i64>,
+}
+
+/// Returns true if `KWin`'s D-Bus service is reachable on the session bus.
+pub(crate) fn is_kwin_available() -> bool {
+    let Ok(conn) = zbus::blocking::Connection::session() else {
+        return false;
+    };
+    let Ok(proxy) = zbus::blocking::fdo::DBusProxy::new(&conn) else {
+        return false;
+    };
+    match KWIN_SERVICE.try_into() {
+        Ok(name) => proxy.name_has_owner(name).unwrap_or(false),
+        Err(_) => false,
+    }
+}
+
+pub(crate) struct KwinScriptingClient {
+    conn: zbus::blocking::Connection,
+    dbus_addr: String,
+    rx: mpsc::Receiver<(String, String)>,
+    seq: std::cell::Cell<u64>,
+}
+
+impl KwinScriptingClient {
+    pub fn new() -> Result<Self> {
+        let conn =
+            zbus::blocking::Connection::session().context("cannot connect to session bus")?;
+        let dbus_addr = conn
+            .unique_name()
+            .context("session connection has no unique name")?
+            .to_string();
+
+        // The KWin script addresses us directly by unique name with an empty
+        // interface, so nothing is registered on an ObjectServer: a dedicated
+        // thread reads the raw method calls off the message stream and
+        // forwards them through a channel. It lives as long as the
+        // connection, and exits once the receiver side is dropped (the send
+        // fails on the next incoming message).
+        let iter = zbus::blocking::MessageIterator::from(conn.clone());
+        let (tx, rx) = mpsc::channel::<(String, String)>();
+        std::thread::Builder::new()
+            .name("espanso-kwin-dbus-callback".to_string())
+            .spawn(move || {
+                for msg in iter.flatten() {
+                    let header = msg.header();
+                    if header.message_type() != zbus::message::Type::MethodCall {
+                        continue;
+                    }
+                    let Some(member) = header.member() else {
+                        continue;
+                    };
+                    let member = member.to_string();
+                    if member != "result" && member != "error" {
+                        continue;
+                    }
+                    let Ok(payload) = msg.body().deserialize::<String>() else {
+                        continue;
+                    };
+                    if tx.send((member, payload)).is_err() {
+                        break;
+                    }
+                }
+            })
+            .context("cannot spawn D-Bus callback thread")?;
+
+        Ok(Self {
+            conn,
+            dbus_addr,
+            rx,
+            seq: std::cell::Cell::new(0),
+        })
+    }
+
+    pub fn get_active_window_info(&self) -> Result<KdeWindowInfo> {
+        let seq = self.seq.get().wrapping_add(1);
+        self.seq.set(seq);
+
+        // Drop replies from previous queries that arrived after their timeout.
+        while self.rx.try_recv().is_ok() {}
+
+        let script = KWIN_SCRIPT
+            .replace("{{dbus_addr}}", &self.dbus_addr)
+            .replace("{{seq}}", &seq.to_string());
+        let script_name = format!("espanso-window-query-{}", std::process::id());
+        let script_path = std::env::temp_dir().join(format!("{script_name}.js"));
+        std::fs::write(&script_path, script).context("cannot write KWin script temp file")?;
+
+        let result = self.run_script(&script_path, &script_name, seq);
+        let _ = std::fs::remove_file(&script_path);
+        result
+    }
+
+    fn run_script(
+        &self,
+        script_path: &std::path::Path,
+        script_name: &str,
+        seq: u64,
+    ) -> Result<KdeWindowInfo> {
+        let script_path_str = script_path.to_str().context("non-UTF8 temp path")?;
+
+        // A leftover script with the same name (e.g. from a crashed run)
+        // makes loadScript fail, so unload defensively first.
+        let _ = self.unload_script(script_name);
+
+        let reply = self
+            .conn
+            .call_method(
+                Some(KWIN_SERVICE),
+                SCRIPTING_PATH,
+                Some(SCRIPTING_INTERFACE),
+                "loadScript",
+                &(script_path_str, script_name),
+            )
+            .context("loadScript failed — is KWin running on this session bus?")?;
+        let script_id: i32 = reply.body().deserialize().context("bad loadScript reply")?;
+        if script_id < 0 {
+            bail!("KWin refused to load the script (id = {})", script_id);
+        }
+
+        let script_obj = format!("{SCRIPTING_PATH}/Script{script_id}");
+        let outcome = self
+            .conn
+            .call_method(
+                Some(KWIN_SERVICE),
+                script_obj.as_str(),
+                Some(SCRIPT_INTERFACE),
+                "run",
+                &(),
+            )
+            .context("Script.run() failed")
+            .and_then(|_| self.wait_for_reply(seq));
+
+        // Best-effort cleanup regardless of outcome.
+        let _ = self.conn.call_method(
+            Some(KWIN_SERVICE),
+            script_obj.as_str(),
+            Some(SCRIPT_INTERFACE),
+            "stop",
+            &(),
+        );
+        let _ = self.unload_script(script_name);
+
+        outcome
+    }
+
+    fn wait_for_reply(&self, seq: u64) -> Result<KdeWindowInfo> {
+        let deadline = std::time::Instant::now() + CALLBACK_TIMEOUT;
+        loop {
+            let remaining = deadline.saturating_duration_since(std::time::Instant::now());
+            match self.rx.recv_timeout(remaining) {
+                Ok((member, payload)) if member == "result" => {
+                    let parsed: serde_json::Value = serde_json::from_str(&payload)
+                        .context("KWin callback payload is not valid JSON")?;
+                    if parsed["seq"].as_u64() != Some(seq) {
+                        // Stale reply from an earlier timed-out query.
+                        continue;
+                    }
+                    return Ok(KdeWindowInfo {
+                        title: parsed["title"].as_str().map(str::to_string),
+                        class_name: parsed["class_name"].as_str().map(str::to_string),
+                        pid: parsed["pid"].as_i64(),
+                    });
+                }
+                Ok((_, payload)) => return Err(anyhow!("KWin script error: {}", payload)),
+                Err(_) => {
+                    return Err(anyhow!(
+                        "timed out after {:?} waiting for the KWin callback",
+                        CALLBACK_TIMEOUT
+                    ))
+                }
+            }
+        }
+    }
+
+    fn unload_script(&self, script_name: &str) -> zbus::Result<zbus::message::Message> {
+        self.conn.call_method(
+            Some(KWIN_SERVICE),
+            SCRIPTING_PATH,
+            Some(SCRIPTING_INTERFACE),
+            "unloadScript",
+            &(script_name,),
+        )
+    }
+}

--- a/espanso-info/src/wayland/mod.rs
+++ b/espanso-info/src/wayland/mod.rs
@@ -21,8 +21,12 @@ use crate::{AppInfo, AppInfoProvider};
 
 use std::process::Command;
 
+pub(crate) mod kde_dbus;
+
 pub(crate) struct WaylandEmptyAppInfoProvider {}
-pub(crate) struct WaylandKDEAppInfoProvider {}
+pub(crate) struct WaylandKDEAppInfoProvider {
+    client: kde_dbus::KwinScriptingClient,
+}
 pub(crate) struct WaylandNiriAppInfoProvider {}
 pub(crate) struct WaylandWlrootsAppInfoProvider {}
 
@@ -47,78 +51,36 @@ impl AppInfoProvider for WaylandEmptyAppInfoProvider {
     }
 }
 
-// for KDE with kdotool
+// for KDE, natively over KWin's scripting D-Bus interface
 impl WaylandKDEAppInfoProvider {
-    pub fn new() -> Self {
-        Self {}
+    pub fn new() -> anyhow::Result<Self> {
+        Ok(Self {
+            client: kde_dbus::KwinScriptingClient::new()?,
+        })
     }
 }
 
 impl AppInfoProvider for WaylandKDEAppInfoProvider {
     fn get_info(&self) -> AppInfo {
-        let class = if let Ok(out) = Command::new("kdotool")
-            .arg("getactivewindow")
-            .arg("getwindowclassname")
-            .output()
-        {
-            let mut __stdout = out.stdout;
-            if !__stdout.is_empty() {
-                __stdout.pop();
+        let info = match self.client.get_active_window_info() {
+            Ok(info) => info,
+            Err(err) => {
+                log::warn!("could not query the active window from KWin: {err:?}");
+                return empty_app_info();
             }
-            let class_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-            Some(class_)
-        } else {
-            // kdotool is checked once in the startup of main.rs
-            // we do not need to log it here again
-            return empty_app_info();
         };
 
-        let title = match Command::new("kdotool")
-            .arg("getactivewindow")
-            .arg("getwindowname")
-            .output()
-        {
-            Ok(out) => {
-                let mut __stdout = out.stdout;
-                if !__stdout.is_empty() {
-                    __stdout.pop();
-                }
-                let title_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-                Some(title_)
-            }
-            Err(_) => None,
-        };
+        let exec = info.pid.and_then(|pid| {
+            std::fs::read_link(format!("/proc/{pid}/exe"))
+                .ok()
+                .map(|path| path.to_string_lossy().into_owned())
+        });
 
-        let exec = match Command::new("kdotool")
-            .arg("getactivewindow")
-            .arg("getwindowpid")
-            .output()
-        {
-            Ok(out) => {
-                let mut __stdout = out.stdout;
-                if !__stdout.is_empty() {
-                    __stdout.pop();
-                }
-                let pid_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-                match Command::new("readlink")
-                    .arg(format!("/proc/{pid_}/exe"))
-                    .output()
-                {
-                    Ok(out) => {
-                        let mut __stdout = out.stdout;
-                        if !__stdout.is_empty() {
-                            __stdout.pop();
-                        }
-                        let exec_ = String::from_utf8(__stdout).expect("Error decoding from utf8");
-                        Some(exec_)
-                    }
-                    Err(_) => None,
-                }
-            }
-            Err(_) => None,
-        };
-
-        AppInfo { title, exec, class }
+        AppInfo {
+            title: info.title,
+            exec,
+            class: info.class_name,
+        }
     }
 }
 

--- a/espanso/src/main.rs
+++ b/espanso/src/main.rs
@@ -22,9 +22,6 @@
 
 use std::path::PathBuf;
 
-#[cfg(target_os = "linux")]
-use std::process::Command;
-
 use clap::{App, AppSettings, Arg, ArgMatches, ErrorKind, SubCommand};
 use cli::{CliModule, CliModuleArgs};
 use log::{error, info, warn};
@@ -626,18 +623,6 @@ SubCommand::with_name("install")
             }
 
             cli_args.paths = Some(paths);
-        }
-
-        // try to invoke `kdotool` to see if you have it or not.
-        #[cfg(target_os = "linux")]
-        if Command::new("kdotool")
-            .arg("getactivewindow")
-            .arg("getwindowclassname")
-            .output()
-            .is_ok()
-        {
-        } else {
-            info!("kdotool missing or not available for the current wayland DE.");
         }
 
         if let Some(args) = matches.subcommand_matches(&handler.subcommand) {


### PR DESCRIPTION
On KDE Plasma Wayland, espanso relied on the external kdotool binary (an optional PATH dependency users had to install separately) to detect the active window for app-specific matching. When missing, app-specific configs silently stopped working (#2162, #2366, #2509).

kdotool itself talks to KWin's scripting D-Bus interface: it loads a small KWin script that reads workspace.activeWindow and reports back via callDBus() addressed at the caller's unique bus name. This commit implements that mechanism directly in espanso-info (zbus, pure Rust):

- espanso-info/src/wayland/kde_dbus.rs: KwinScriptingClient owns a session-bus connection and a receiver thread (created once per provider, not per query); a sequence number in the JSON payload guards against stale replies from timed-out queries.
- WaylandKDEAppInfoProvider now queries title/class/pid in a single round trip (previously 3 kdotool subprocesses + readlink per query) and no longer panics on non-UTF8 output.
- Provider selection probes NameHasOwner("org.kde.KWin") instead of spawning kdotool; the duplicate startup probe in main.rs (which also ran on X11 builds and caused log spam, #2366/#2509) is removed.
- zbus is MIT-licensed, already in Cargo.lock (via notify-rust), and scoped to Linux + the wayland feature, so X11/macOS/Windows builds are unaffected.

Like kdotool, this requires KWin's scripting interface (Plasma 5/6); tested against KWin 6.7.3 (kwin_wayland --virtual) with XWayland and native-Wayland clients, including app-specific filter_class matching, with kdotool absent from the system.