### PR TITLE
fix(daemon/macos): take over stale daemon lock after logout/login

### DIFF
--- a/espanso/src/cli/daemon/mod.rs
+++ b/espanso/src/cli/daemon/mod.rs
@@ -68,6 +68,14 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
 
     // Make sure only one instance of the daemon is running
     let lock_file = acquire_daemon_lock(&paths.runtime);
+
+    // On macOS, a daemon from a previous login session can survive a
+    // logout/login (see GitHub issue #1492), keeping the daemon lock held while
+    // no longer serving the current session. In that case, try to take over
+    // from the stale daemon instead of giving up.
+    #[cfg(target_os = "macos")]
+    let lock_file = lock_file.or_else(|| reclaim_stale_daemon_lock(&paths.runtime));
+
     if lock_file.is_none() {
         error!("daemon is already running!");
         return DAEMON_ALREADY_RUNNING;
@@ -192,6 +200,50 @@ fn daemon_main(args: CliModuleArgs) -> i32 {
     }
 
     DAEMON_SUCCESS
+}
+
+// Take over the daemon lock from a stale daemon that survived a previous login
+// session (macOS, GitHub issue #1492). We first ask the existing daemon to
+// exit so it releases the lock cleanly (which also tears down its worker); if
+// it does not release within a short window (e.g. it is wedged), we clear the
+// stale lock file so a fresh daemon can acquire a new one.
+#[cfg(target_os = "macos")]
+fn reclaim_stale_daemon_lock(runtime_dir: &Path) -> Option<crate::lock::Lock> {
+    warn!("daemon lock is held, attempting to take over from a possibly stale daemon...");
+
+    // Ask the existing daemon to exit. A live, responsive daemon releases the
+    // lock (and shuts down its worker); a duplicate launch simply hands off.
+    match crate::ipc::create_ipc_client_to_daemon(runtime_dir) {
+        Ok(mut daemon_ipc) => {
+            if let Err(err) = daemon_ipc.send_async(IPCEvent::Exit) {
+                error!("unable to send termination signal to daemon process: {err}");
+            }
+        }
+        Err(err) => {
+            error!("could not establish IPC connection with daemon: {err}");
+        }
+    }
+
+    // Wait for the stale daemon to release the lock.
+    let now = Instant::now();
+    while now.elapsed() < std::time::Duration::from_secs(3) {
+        if let Some(lock) = acquire_daemon_lock(runtime_dir) {
+            return Some(lock);
+        }
+
+        std::thread::sleep(std::time::Duration::from_millis(200));
+    }
+
+    // The holder did not release the lock (e.g. an unresponsive orphan). Clear
+    // the stale lock file so a fresh daemon can acquire a new one; the orphan
+    // keeps its now-unlinked lock file and no longer blocks us.
+    warn!("stale daemon did not release the lock, clearing the stale lock file");
+    if let Err(err) = crate::lock::clear_daemon_lock(runtime_dir) {
+        error!("unable to clear stale daemon lock file: {err}");
+        return None;
+    }
+
+    acquire_daemon_lock(runtime_dir)
 }
 
 fn terminate_worker_if_already_running(runtime_dir: &Path) {

--- a/espanso/src/ipc.rs
+++ b/espanso/src/ipc.rs
@@ -54,6 +54,11 @@ pub fn create_ipc_client_to_worker(runtime_dir: &Path) -> Result<impl IPCClient<
     create_ipc_client(runtime_dir, "workerv2")
 }
 
+#[cfg(target_os = "macos")]
+pub fn create_ipc_client_to_daemon(runtime_dir: &Path) -> Result<impl IPCClient<IPCEvent>> {
+    create_ipc_client(runtime_dir, "daemonv2")
+}
+
 fn create_ipc_server(runtime_dir: &Path, name: &str) -> Result<impl IPCServer<IPCEvent>> {
     espanso_ipc::server(&format!("espanso{name}"), runtime_dir)
 }

--- a/espanso/src/lock.rs
+++ b/espanso/src/lock.rs
@@ -21,8 +21,15 @@ use anyhow::Result;
 use fs2::FileExt;
 use std::{
     fs::{File, OpenOptions},
-    path::Path,
+    path::{Path, PathBuf},
 };
+
+const DAEMON_LOCK_NAME: &str = "espanso-daemon";
+const WORKER_LOCK_NAME: &str = "espanso-worker";
+
+fn lock_file_path(runtime_dir: &Path, name: &str) -> PathBuf {
+    runtime_dir.join(format!("{name}.lock"))
+}
 
 pub struct Lock {
     lock_file: File,
@@ -36,7 +43,7 @@ impl Lock {
     }
 
     fn acquire(runtime_dir: &Path, name: &str) -> Option<Lock> {
-        let lock_file_path = runtime_dir.join(format!("{name}.lock"));
+        let lock_file_path = lock_file_path(runtime_dir, name);
         let lock_file = OpenOptions::new()
             .read(true)
             .write(true)
@@ -65,9 +72,47 @@ impl Drop for Lock {
 }
 
 pub fn acquire_daemon_lock(runtime_dir: &Path) -> Option<Lock> {
-    Lock::acquire(runtime_dir, "espanso-daemon")
+    Lock::acquire(runtime_dir, DAEMON_LOCK_NAME)
 }
 
 pub fn acquire_worker_lock(runtime_dir: &Path) -> Option<Lock> {
-    Lock::acquire(runtime_dir, "espanso-worker")
+    Lock::acquire(runtime_dir, WORKER_LOCK_NAME)
+}
+
+#[cfg(target_os = "macos")]
+pub fn clear_daemon_lock(runtime_dir: &Path) -> Result<()> {
+    let lock_file_path = lock_file_path(runtime_dir, DAEMON_LOCK_NAME);
+    if lock_file_path.exists() {
+        std::fs::remove_file(&lock_file_path)?;
+    }
+    Ok(())
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+    use tempdir::TempDir;
+
+    #[test]
+    fn clear_daemon_lock_allows_takeover_while_stale_lock_is_held() {
+        let dir = TempDir::new("espansolock").unwrap();
+        let runtime = dir.path();
+
+        // An orphaned daemon acquires the lock and keeps holding it.
+        let orphan = acquire_daemon_lock(runtime);
+        assert!(orphan.is_some());
+
+        // A new daemon can't acquire the lock while the orphan holds it.
+        assert!(acquire_daemon_lock(runtime).is_none());
+
+        // Clearing the stale lock file lets the new daemon take over, even
+        // though the orphan is still holding its (now unlinked) lock file.
+        clear_daemon_lock(runtime).unwrap();
+        let takeover = acquire_daemon_lock(runtime);
+        assert!(takeover.is_some());
+
+        // Keep the orphan alive until the end so the assertion above proves
+        // the inode swap works, not that the orphan simply released.
+        drop(orphan);
+    }
 }


### PR DESCRIPTION
## Problem

As reported in #1492.

On macOS, espanso can appear to be running after login, but expansions don't work. I assume it would apply to fast user switch as well, but did not verify this myself. `espanso status` reports a running instance, but nothing expands until the process 
is manually killed and restarted.

A `daemon` process from the previous login session seems to survive into the new session. It holds the daemon lock, but isn't serving the current session. When the new session starts espanso, the new daemon can't acquire the lock, logs `daemon is already running!`, and exits. Because the stale daemon is still there, repeated logins leave several dead espanso processes behind as noted in the issue.

## Root cause

The daemon lock (`espanso/src/lock.rs`) is an advisory `flock` held by an open file descriptor, so the OS releases it automatically when the holding process dies. A lock that is still held implies a *live* process is holding it.

On macOS, the previous session's `daemon` is not reliably torn down on logout, so it stays alive into the next session and keeps holding the lock. In `daemon_main` (`espanso/src/cli/daemon/mod.rs`), the startup path did:

    let lock_file = acquire_daemon_lock(&paths.runtime);
    if lock_file.is_none() {
        error!("daemon is already running!");
        return DAEMON_ALREADY_RUNNING;
    }

So the new session's daemon could never acquire the lock from the stale holder: it returned `DAEMON_ALREADY_RUNNING` and exited. Nothing tried to reclaim the lock or to shut the stale daemon down so dead processes may accumulate.

## Fix

On macOS, when the daemon lock is already held, the new daemon now tries to take over from the (presumed stale) holder instead of giving up. It:

- Asks the existing daemon to exit over IPC (`IPCEvent::Exit`) and wait up to 3s for it to release the lock, then acquire it. A live, responsive daemon shuts down cleanly and hands off.
- If the holder is wedged and does not release in time, it clears the stale lock file and acquires a fresh one. The stale process keeps its now-unlinked lock file and no longer blocks startup.
- The daemon's existing `terminate_worker_if_already_running` step then shuts down the old session's worker, so no daemon/worker processes accumulate across relogins.

I tried to mirror the existing `terminate_worker_if_already_running` pattern (same 3s / 200ms poll), applied to the daemon instead of the worker.

The change is gated behind `#[cfg(target_os = "macos")]`, so Linux and Windows startup behavior is unchanged. Supporting additions:

- `lock::clear_daemon_lock` (removes the stale daemon lock file) and a small `lock_file_path` helper / name-constant refactor so the path is defined once.
- `ipc::create_ipc_client_to_daemon`, mirroring the existing `create_ipc_client_to_worker`.

## Testing

A unit test in `lock.rs` covers the take-over mechanism: an orphan holds the lock, and clearing the stale lock file lets a new lock be acquired while the orphan's now-unlinked file is still held.

Manual test on macOS with two real `espanso daemon` processes against isolated `--config_dir` / `--runtime_dir` dirs:

- **Responsive orphan (graceful):** daemon A holds the lock; starting daemon B logs `daemon lock is held, attempting to take over from a possibly stale daemon...` then proceeds. Daemon A exits and its worker self-exits (`detected unexpected daemon termination... exiting worker process`). Result: exactly one daemon + one worker, no leftovers.
- **Wedged orphan (fallback):** daemon A frozen with `SIGSTOP` so it can't answer IPC; starting daemon B waits ~3s, logs `stale daemon did not release the lock, clearing the stale lock file`, then takes over.
- In both cases the new daemon never prints `daemon is already running!`.

Not exercised: a literal macOS logout/login cycle. The two-process test drives the exact code path a relogin hits (lock held by a live daemon → take over).

On CI: out of an abundance of caution I did not enable GitHub Actions on my fork, so the workflows have not run against these commits. I reproduced the `macos` job locally on Apple Silicon:

* `cargo fmt --all -- --check`
* `cargo test --workspace`
* `cargo clippy -- --deny warnings` 

All passed. 

I did not verify other platforms. I'll leave that to CI.

## Note

As mentioned, this changes is scoped intentionally to macOS. The bug is macOS-specific (the previous session's daemon surviving a logout/login), reproduction needs a Mac, and gating keeps Linux/Windows startup untouched. I'll be happy to generalize the mechanism if maintainers would prefer a unified, cross-platform fix.

Related: #2725 also touches `daemon/mod.rs` and reworks the worker-exit handling. This change appears independent (a different bug, and a different region of the file: lock acquisition + a new take-over helper), so I don't anticipate any conflict on `dev`, but whichever lands second may need a trivial rebase.

While verifying, I noticed a pre-existing, separate quirk: a graceful daemon shutdown over IPC logs `received unexpected exit code from worker 0, exiting` at ERROR level even though it exits cleanly. It sits in the same exit-handling code #2725 is reworking, so I left it out of this PR.

Closes #1492.
