### PR TITLE
Fix intermittent plain v on macOS clipboard expansion

### DIFF
--- a/espanso-inject/src/mac/native.mm
+++ b/espanso-inject/src/mac/native.mm
@@ -27,6 +27,32 @@
 // so that we can later skip them in the detect module.
 CGPoint ESPANSO_POINT_MARKER = CGPointMake(-27469, 0);
 
+// Return the Quartz modifier flag associated with a macOS virtual key code.
+// A combination's non-modifier events need explicit flags: relying only on a
+// separately posted modifier key-down is racy and can turn CMD+V into plain V
+// (https://github.com/espanso/espanso/issues/1288).
+static CGEventFlags modifier_flag_for_vkey(int32_t vkey)
+{
+  switch (vkey) {
+    case 0x36: // Right Command
+    case 0x37: // Left Command
+      return kCGEventFlagMaskCommand;
+    case 0x38: // Left Shift
+    case 0x3C: // Right Shift
+      return kCGEventFlagMaskShift;
+    case 0x3A: // Left Option
+    case 0x3D: // Right Option
+      return kCGEventFlagMaskAlternate;
+    case 0x3B: // Left Control
+    case 0x3E: // Right Control
+      return kCGEventFlagMaskControl;
+    case 0x39: // Caps Lock
+      return kCGEventFlagMaskAlphaShift;
+    default:
+      return 0;
+  }
+}
+
 void inject_string(char *string, int32_t default_delay, int32_t delay)
 {
   long udelay = delay * 1000;
@@ -134,11 +160,16 @@ void inject_vkeys_combination(int32_t *_vkey_array, int32_t vkey_count, int32_t 
 
   dispatch_async(dispatch_get_main_queue(), ^(void) {
     @autoreleasepool {
+      CGEventFlags flags = 0;
+
       // First send the presses
       for (int i = 0; i < vkey_count; i++)
       {
+        flags |= modifier_flag_for_vkey(vkey_array[i]);
+
         CGEventRef keydown;
         keydown = CGEventCreateKeyboardEvent(NULL, vkey_array[i], true);
+        CGEventSetFlags(keydown, flags);
         CGEventSetLocation(keydown, ESPANSO_POINT_MARKER);
         CGEventPost(kCGHIDEventTap, keydown);
         CFRelease(keydown);
@@ -149,8 +180,11 @@ void inject_vkeys_combination(int32_t *_vkey_array, int32_t vkey_count, int32_t 
       // Then the releases
       for (int i = (vkey_count - 1); i >= 0; i--)
       {
+        flags &= ~modifier_flag_for_vkey(vkey_array[i]);
+
         CGEventRef keyup;
         keyup = CGEventCreateKeyboardEvent(NULL, vkey_array[i], false);
+        CGEventSetFlags(keyup, flags);
         CGEventSetLocation(keyup, ESPANSO_POINT_MARKER);
         CGEventPost(kCGHIDEventTap, keyup);
         CFRelease(keyup);


### PR DESCRIPTION
## Summary

- attach explicit Quartz modifier flags to every synthesized key event in a virtual-key combination
- preserve the active modifier state while pressing and releasing the combination
- prevent an intended Command-V paste from intermittently arriving as a plain `v` on macOS

Fixes #1288.

## Root cause

`inject_vkeys_combination` posted the modifier key-down and the non-modifier key-down as separate events, but did not set `CGEventFlags` on either event. Under some timing conditions, the target application could process the V event without the Command modifier and insert a literal `v`.

The change derives Quartz flags from the virtual modifier keys, accumulates them during key-down, and removes them during reverse-order key-up. The V key-down and key-up therefore explicitly carry `kCGEventFlagMaskCommand` during a Command-V combination.

## User impact

Clipboard-mode expansions retain their fast insertion behavior while avoiding the intermittent lone-`v` failure. This removes the need to work around the issue with slower character-by-character injection.

## Validation

- `cargo test -p espanso-inject` — 3 passed
- `cargo clippy -p espanso-inject --all-targets -- -D warnings` — passed
- `cargo fmt --all -- --check` — passed
- Objective-C++ `-fsyntax-only` check with warnings treated as errors, excluding two pre-existing sign-comparison warnings — passed
- manual Apple Silicon field test on macOS 14.8.9 with Espanso 2.4.0 across MailMate, iTerm2, Safari, and native Save As dialogs: repeated long and short clipboard expansions produced no lone `v` failures after the unpatched path had failed frequently; behavior remained clean after configuration reloads
