### PR TITLE
fix(render): avoid panic when capitalize casing is applied to empty body

### DIFF
--- a/espanso-render/src/renderer/mod.rs
+++ b/espanso-render/src/renderer/mod.rs
@@ -184,7 +184,9 @@ impl Renderer for DefaultRenderer<'_> {
             CasingStyle::Capitalize => {
                 // Capitalize the first letter
                 let mut v: Vec<char> = body.chars().collect();
-                v[0] = v[0].to_uppercase().next().unwrap();
+                if let Some(first) = v.first_mut() {
+                    *first = first.to_uppercase().next().unwrap();
+                }
                 v.into_iter().collect()
             }
             CasingStyle::CapitalizeWords => {
@@ -354,6 +356,26 @@ mod tests {
             },
         );
         assert!(matches!(res, RenderResult::Success(str) if str == "Plain body"));
+    }
+
+    #[test]
+    fn capitalize_empty_body_does_not_panic() {
+        // The casing style is derived from the typed trigger (propagate_case),
+        // which is independent of the rendered body. A match whose body
+        // resolves to an empty string (e.g. `replace: ""`, or a variable that
+        // yields an empty result) used to index an empty Vec and panic.
+        let renderer = get_renderer();
+        let res = renderer.render(
+            &template_for_str(""),
+            &Context::default(),
+            &RenderOptions {
+                casing_style: CasingStyle::Capitalize,
+            },
+        );
+        let RenderResult::Success(rendered) = res else {
+            panic!("expected success, got {res:?}");
+        };
+        assert!(rendered.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Problem

The `Capitalize` casing style capitalizes the first character of the rendered body. It did so by indexing a `Vec<char>` directly:

```rust
CasingStyle::Capitalize => {
    let mut v: Vec<char> = body.chars().collect();
    v[0] = v[0].to_uppercase().next().unwrap();  // panics if body is empty
    v.into_iter().collect()
}
```

When the body was empty, `v[0]` was an out-of-bounds access and the renderer panicked:

```
index out of bounds: the len is 0 but the index is 0
```

## Root cause

The casing style is derived from the typed trigger (`propagate_case` in `espanso/src/cli/worker/engine/process/middleware/render/mod.rs`), which is independent of the rendered body. A match whose body resolves to an empty string — e.g. `replace: ""`, or a `shell`/`date`/`form` variable that returns an empty result — with `propagate_case: true` reached this branch and crashed rendering for that match.

`CapitalizeWords` was already safe here (the `WORD_REGEX.replace_all` closure is never called on an empty body), but `Capitalize` was not.

## Fix

Guard the access with `first_mut` so an empty body is returned unchanged (`espanso-render/src/renderer/mod.rs`):

```rust
CasingStyle::Capitalize => {
    let mut v: Vec<char> = body.chars().collect();
    if let Some(first) = v.first_mut() {
        *first = first.to_uppercase().next().unwrap();
    }
    v.into_iter().collect()
}
```

## Test plan

Added `capitalize_empty_body_does_not_panic`, which renders an empty body with `CasingStyle::Capitalize` and asserts a `Success("")` result.

- Red before the fix: `panicked at 'index out of bounds: the len is 0 but the index is 0'`.
- Green after: `cargo test -p espanso-render` — 59 passed, 0 failed.
- `cargo fmt --all -- --check` — clean; `cargo clippy -p espanso-render --all-targets -- --deny warnings` — clean.

Authored on macOS arm64; the touched code is pure Rust with no platform conditionals.
