### PR TITLE
fix(render): coerce numeric and boolean echo params

### DIFF
--- a/espanso-render/src/extension/echo.rs
+++ b/espanso-render/src/extension/echo.rs
@@ -17,7 +17,7 @@
  * along with espanso.  If not, see <https://www.gnu.org/licenses/>.
  */
 
-use crate::{Extension, ExtensionOutput, ExtensionResult, Params, Value};
+use crate::{Extension, ExtensionOutput, ExtensionResult, Number, Params, Value};
 use thiserror::Error;
 
 pub struct EchoExtension {
@@ -49,10 +49,19 @@ impl Extension for EchoExtension {
         _: &crate::Scope,
         params: &Params,
     ) -> crate::ExtensionResult {
-        if let Some(Value::String(echo)) = params.get("echo") {
-            ExtensionResult::Success(ExtensionOutput::Single(echo.clone()))
-        } else {
-            ExtensionResult::Error(EchoExtensionError::MissingEchoParameter.into())
+        // YAML scalars arrive unquoted as numbers and booleans, so coerce them
+        // rather than making users quote every value
+        let echo = match params.get("echo") {
+            Some(Value::String(value)) => Some(value.clone()),
+            Some(Value::Number(Number::Integer(value))) => Some(value.to_string()),
+            Some(Value::Number(Number::Float(value))) => Some(value.to_string()),
+            Some(Value::Bool(value)) => Some(value.to_string()),
+            _ => None,
+        };
+
+        match echo {
+            Some(echo) => ExtensionResult::Success(ExtensionOutput::Single(echo)),
+            None => ExtensionResult::Error(EchoExtensionError::MissingEchoParameter.into()),
         }
     }
 }
@@ -69,6 +78,14 @@ mod tests {
 
     use super::*;
 
+    fn echo(value: Value) -> ExtensionResult {
+        let extension = EchoExtension::new();
+        let param = vec![("echo".to_string(), value)]
+            .into_iter()
+            .collect::<Params>();
+        extension.calculate(&crate::Context::default(), &HashMap::default(), &param)
+    }
+
     #[test]
     fn echo_works_correctly() {
         let extension = EchoExtension::new();
@@ -83,6 +100,34 @@ mod tests {
                 .unwrap(),
             ExtensionOutput::Single("test".to_string())
         );
+    }
+
+    #[test]
+    fn echo_coerces_scalars() {
+        for (value, expected) in [
+            (Value::Number(Number::Integer(12345)), "12345"),
+            (Value::Number(Number::Integer(-1)), "-1"),
+            (Value::Number(Number::Float(1.0)), "1"),
+            (Value::Number(Number::Float(1.5)), "1.5"),
+            (Value::Bool(true), "true"),
+            (Value::Bool(false), "false"),
+        ] {
+            assert_eq!(
+                echo(value).into_success().unwrap(),
+                ExtensionOutput::Single(expected.to_string())
+            );
+        }
+    }
+
+    #[test]
+    fn echo_rejects_non_scalars() {
+        for value in [
+            Value::Null,
+            Value::Array(vec![Value::Bool(true)]),
+            Value::Object(HashMap::new()),
+        ] {
+            assert!(matches!(echo(value), ExtensionResult::Error(_)));
+        }
     }
 
     #[test]

--- a/schemas/match.schema.json
+++ b/schemas/match.schema.json
@@ -1209,7 +1209,7 @@
               "additionalProperties": false,
               "properties": {
                 "echo": {
-                  "type": "string"
+                  "type": ["string", "number", "boolean"]
                 }
               }
             },


### PR DESCRIPTION
Fixes #2722.

## The problem

A numeric `global_vars` entry fails to render, with an error that says the parameter is missing when it is right there:

```yaml
global_vars:
  - name: myvar
    type: echo
    params:
      echo: 12345
```

The YAML loader is doing the right thing: an unquoted `12345` is a YAML integer, so `convert_value` produces `Value::Number(Number::Integer(12345))` (`espanso-config/src/matches/group/loader/yaml/util.rs:44`). But the echo extension only ever matched `Value::String`:

```rust
if let Some(Value::String(echo)) = params.get("echo") {
```

so anything else fell to the `else` and reported `missing 'echo' parameter`. The user has to know to quote the value, and the error points them nowhere near that.

I confirmed the three cases before touching anything:

```
number   => Error(missing 'echo' parameter)
bool     => Error(missing 'echo' parameter)
string   => Success(Single("12345"))
```

@smeech noted in the thread that this is intentional YAML behaviour and that coercion is what's actually wanted here, the way `replace:` values already get coerced. This PR does exactly that, for `echo` only — `date`'s `offset:` still needs a real number, so I left it alone.

## The fix

Match numbers and booleans too, formatting each explicitly:

- `Number::Integer` / `Number::Float` via `to_string()` — shortest round-trip, so `0.1` stays `0.1` and `1e20` expands in full with no precision loss
- `Bool` as `true` / `false`

`Null`, `Array` and `Object` still error. `Null` is what a bare `echo:` produces, and rendering it as `null` would be worse than failing; arrays and objects have no sensible single-string form, and formatting them via `Debug` would leak Rust syntax into the user's text.

`schemas/match.schema.json` is widened to `["string", "number", "boolean"]` in the same commit, otherwise the editor extensions would keep red-underlining exactly the config this makes valid.

One thing worth knowing: `Number::Float(1.0)` renders as `1`, not `1.0`. That's Rust's float formatting and it's pinned in the tests so it isn't a surprise later.

## Tests

Two new tests alongside the existing ones: `echo_coerces_scalars` covers integers (including negative), floats (`1.0` and `1.5`), and both booleans; `echo_rejects_non_scalars` pins that `Null`/`Array`/`Object` keep erroring.

```
cargo test -p espanso-render   => ok. 60 passed; 0 failed
cargo test -p espanso-config   => ok. 79 passed; 0 failed
cargo fmt --check -p espanso-render      => clean
cargo clippy -p espanso-render --all-targets -- --deny warnings  => exit 0
```
