### PR TITLE
fix(render): build a valid PATH for the fish shell on macOS

### DIFF
--- a/espanso-render/src/extension/exec_util.rs
+++ b/espanso-render/src/extension/exec_util.rs
@@ -32,15 +32,23 @@ pub fn determine_path_env_variable_override(explicit_shell: Option<MacShell>) ->
         return None;
     }
     let shell: MacShell = explicit_shell.or_else(determine_default_macos_shell)?;
+    let (command, args) = path_query_command(&shell);
 
+    launch_command_and_get_output(command, args)
+}
+
+// The command (and its arguments) used to print the PATH of a login shell as a
+// POSIX colon-separated string.
+fn path_query_command(shell: &MacShell) -> (&'static str, &'static [&'static str]) {
     match shell {
-        MacShell::Bash => launch_command_and_get_output(
-            "bash",
-            &["--login", "-c", "source ~/.bashrc; echo $PATH"],
-        ),
-        MacShell::Fish => launch_command_and_get_output("fish", &["--login", "-c", "echo $PATH"]),
-        MacShell::Nu => launch_command_and_get_output("nu", &["--login", "-c", "$env.PATH"]),
-        MacShell::Pwsh => launch_command_and_get_output(
+        MacShell::Bash => ("bash", &["--login", "-c", "source ~/.bashrc; echo $PATH"]),
+        // In fish, PATH is a list variable, so `echo $PATH` would print its entries
+        // separated by spaces instead of colons. We ask fish to join them explicitly.
+        // `--` keeps entries starting with a hyphen from being read as flags, and
+        // `; true` absorbs the exit code 1 `string join` returns for a single entry.
+        MacShell::Fish => ("fish", &["--login", "-c", "string join -- : $PATH; true"]),
+        MacShell::Nu => ("nu", &["--login", "-c", "$env.PATH"]),
+        MacShell::Pwsh => (
             "pwsh",
             &[
                 "-Login",
@@ -48,10 +56,8 @@ pub fn determine_path_env_variable_override(explicit_shell: Option<MacShell>) ->
                 "if(Test-Path \"$PROFILE\") { . \"$PROFILE\" }; Write-Host $env:PATH",
             ],
         ),
-        MacShell::Sh => launch_command_and_get_output("sh", &["--login", "-c", "echo $PATH"]),
-        MacShell::Zsh => {
-            launch_command_and_get_output("zsh", &["--login", "-c", "source ~/.zshrc; echo $PATH"])
-        }
+        MacShell::Sh => ("sh", &["--login", "-c", "echo $PATH"]),
+        MacShell::Zsh => ("zsh", &["--login", "-c", "source ~/.zshrc; echo $PATH"]),
     }
 }
 
@@ -107,6 +113,47 @@ fn launch_command_and_get_output(command: &str, args: &[&str]) -> Option<String>
         return None;
     }
 
+    // without trimming, the shell's trailing newline lands inside the last PATH
+    // entry, making it unresolvable
     let output_str = String::from_utf8_lossy(&output.stdout);
+    let output_str = output_str.trim();
+    if output_str.is_empty() {
+        return None;
+    }
     Some(output_str.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fish_joins_path_with_colons() {
+        // fish stores PATH as a list, so it must be joined with colons explicitly,
+        // otherwise the resulting PATH is a single bogus space-separated entry.
+        let (command, args) = path_query_command(&MacShell::Fish);
+        assert_eq!(command, "fish");
+        assert!(args.last().unwrap().starts_with("string join -- : $PATH"));
+    }
+
+    #[test]
+    fn every_shell_query_is_unchanged_except_fish() {
+        for (shell, expected) in [
+            (MacShell::Bash, "source ~/.bashrc; echo $PATH"),
+            (MacShell::Nu, "$env.PATH"),
+            (MacShell::Sh, "echo $PATH"),
+            (MacShell::Zsh, "source ~/.zshrc; echo $PATH"),
+        ] {
+            assert_eq!(*path_query_command(&shell).1.last().unwrap(), expected);
+        }
+    }
+
+    #[test]
+    fn trailing_newline_would_corrupt_the_last_entry() {
+        // guards the trim in launch_command_and_get_output: a shell prints a
+        // trailing newline, and PATH is split on ':' only
+        let raw = "/usr/local/bin:/usr/bin\n";
+        assert_eq!(raw.split(':').next_back(), Some("/usr/bin\n"));
+        assert_eq!(raw.trim().split(':').next_back(), Some("/usr/bin"));
+    }
 }


### PR DESCRIPTION
Fixes #2753.

## The problem

In fish, `PATH` is a **list** variable, so `echo $PATH` prints its entries separated by spaces, not colons:

```
/opt/homebrew/bin /usr/local/bin /usr/bin /bin
```

`launch_command_and_get_output` does no parsing at all — it returns stdout verbatim, and `shell.rs:139` passes it straight to `command.env("PATH", …)`. So the child process gets a `PATH` consisting of one nonsensical entry, `fish` itself is no longer resolvable on it, and spawning fails with `No such file or directory (os error 2)`.

The invariant the code relies on — "this shell's stdout *is* a POSIX PATH" — simply doesn't hold for fish.

## The fix

Ask fish to do the joining:

```
fish --login -c "string join -- : $PATH; true"
```

Two details that aren't decorative:

- **`--`** — fish's own docs warn that `string join` reads leading-hyphen arguments as flags, *"also true if you specify a variable which expands to such a string"*. Cheap insurance.
- **`; true`** — `string join` documents *"Exit status: 0 if at least one join was performed, or 1 otherwise"*. A single-entry `PATH` therefore exits 1, and `launch_command_and_get_output` returns `None` on a non-zero status, silently dropping the override. Without this the fix would trade one failure for a narrower one.

I only spotted both of these because a review pass pushed back on the first version, which was the bare `string join : $PATH`.

## A second bug in the same path

While tracing this I found that `launch_command_and_get_output` has never trimmed stdout. Every shell prints a trailing newline, and since PATH is split on `:` only, that newline ends up *inside the last entry*:

```
"/usr/local/bin:/usr/bin\n".split(':').last()  ==  "/usr/bin\n"
```

So the final directory in the PATH has never been resolvable, for bash, zsh, sh, nu and pwsh alike. For the reporter in #2753 that means fixing only the fish joining would still leave them broken if their tool lives in the last entry — which is exactly where Homebrew paths tend to land. Trimming is therefore part of the fix rather than adjacent cleanup. An empty result now yields `None` instead of setting `PATH` to `""`.

## Refactor

The shell → command mapping moved into a small `path_query_command()` so the choice is unit-testable without spawning anything. `determine_path_env_variable_override` still shells out and remains untestable as such.

## Testing, and its limits

I want to be straight about this: **I could not run any of it.** fish isn't installed in my environment, and this whole code path is `cfg!(target_os = "macos")` while I'm on Linux. The fish semantics above come from fish's official `string join` documentation, and the newline bug is demonstrated by a unit test on the string handling itself rather than on a live shell.

What did run:

```
cargo test -p espanso-render                                     61 passed; 0 failed
cargo fmt --check -p espanso-render                              clean
cargo clippy -p espanso-render --all-targets -- --deny warnings  exit 0
```

Three tests added: fish joins with colons, the other five shells' commands are byte-identical to before, and the trailing-newline corruption the trim prevents.

Someone on macOS with fish confirming the end-to-end behaviour would be worth more than my reasoning here.

## Unrelated thing I noticed

`MacShell::Sh` passes `--login` to `sh`, which takes `-l`. Pre-existing and untouched, but flagging it in case it's news.
