### PR TITLE
Add support for some pointer-operated virtual keyboards

### DIFF
--- a/espanso-config/src/config/mod.rs
+++ b/espanso-config/src/config/mod.rs
@@ -140,6 +140,13 @@ pub trait Config: Send + Sync {
     // presses the Backspace key afterwards.
     fn undo_backspace(&self) -> bool;
 
+    // If true, preserve the matcher state for pointer-operated virtual
+    // keyboards that emit keyboard events between mouse press and release.
+    // Disabled by default to preserve the existing mouse invalidation behavior.
+    fn support_virtual_keyboard(&self) -> bool {
+        false
+    }
+
     // If false, disable all notifications
     fn show_notifications(&self) -> bool;
 

--- a/espanso-config/src/config/parse/mod.rs
+++ b/espanso-config/src/config/parse/mod.rs
@@ -41,6 +41,7 @@ pub struct ParsedConfig {
     pub search_trigger: Option<String>,
     pub search_shortcut: Option<String>,
     pub undo_backspace: Option<bool>,
+    pub support_virtual_keyboard: Option<bool>,
     pub show_notifications: Option<bool>,
     pub show_icon: Option<bool>,
     pub secure_input_notification: Option<bool>,

--- a/espanso-config/src/config/parse/yaml.rs
+++ b/espanso-config/src/config/parse/yaml.rs
@@ -104,6 +104,9 @@ pub struct YAMLConfig {
     pub undo_backspace: Option<bool>,
 
     #[serde(default)]
+    pub support_virtual_keyboard: Option<bool>,
+
+    #[serde(default)]
     pub show_notifications: Option<bool>,
 
     #[serde(default)]
@@ -227,6 +230,7 @@ impl TryFrom<YAMLConfig> for ParsedConfig {
             search_trigger: yaml_config.search_trigger,
             search_shortcut: yaml_config.search_shortcut,
             undo_backspace: yaml_config.undo_backspace,
+            support_virtual_keyboard: yaml_config.support_virtual_keyboard,
 
             show_icon: yaml_config.show_icon,
             show_notifications: yaml_config.show_notifications,
@@ -303,6 +307,7 @@ mod tests {
     search_trigger: "search"
     search_shortcut: "CTRL+SPACE"
     undo_backspace: false
+    support_virtual_keyboard: true
     show_icon: false
     show_notifications: false
     secure_input_notification: false
@@ -364,6 +369,7 @@ mod tests {
                 search_trigger: Some("search".to_owned()),
                 search_shortcut: Some("CTRL+SPACE".to_owned()),
                 undo_backspace: Some(false),
+                support_virtual_keyboard: Some(true),
                 show_icon: Some(false),
                 show_notifications: Some(false),
                 secure_input_notification: Some(false),

--- a/espanso-config/src/config/resolve.rs
+++ b/espanso-config/src/config/resolve.rs
@@ -294,6 +294,10 @@ impl Config for ResolvedConfig {
         self.parsed.undo_backspace.unwrap_or(true)
     }
 
+    fn support_virtual_keyboard(&self) -> bool {
+        self.parsed.support_virtual_keyboard.unwrap_or(false)
+    }
+
     fn show_icon(&self) -> bool {
         self.parsed.show_icon.unwrap_or(true)
     }
@@ -442,6 +446,7 @@ impl ResolvedConfig {
             search_trigger,
             search_shortcut,
             undo_backspace,
+            support_virtual_keyboard,
             show_icon,
             show_notifications,
             secure_input_notification,
@@ -536,6 +541,25 @@ mod tests {
     use super::*;
     use crate::util::tests::use_test_directory;
     use std::fs::create_dir_all;
+
+    #[test]
+    fn support_virtual_keyboard_defaults_to_false() {
+        let config = ResolvedConfig::default();
+        assert!(!config.support_virtual_keyboard());
+    }
+
+    #[test]
+    fn support_virtual_keyboard_can_be_enabled() {
+        let config = ResolvedConfig {
+            parsed: ParsedConfig {
+                support_virtual_keyboard: Some(true),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        assert!(config.support_virtual_keyboard());
+    }
 
     #[test]
     fn aggregate_includes_empty_config() {

--- a/espanso-engine/src/process/middleware/matcher.rs
+++ b/espanso-engine/src/process/middleware/matcher.rs
@@ -19,7 +19,7 @@
 
 use log::trace;
 use std::{
-    cell::RefCell,
+    cell::{Cell, RefCell},
     collections::{HashMap, VecDeque},
 };
 
@@ -55,6 +55,7 @@ pub struct MatchResult {
 
 pub trait MatcherMiddlewareConfigProvider {
     fn max_history_size(&self) -> usize;
+    fn support_virtual_keyboard(&self) -> bool;
 }
 
 pub trait ModifierStateProvider {
@@ -74,6 +75,10 @@ pub struct MatcherMiddleware<'a, State> {
     matcher_states: RefCell<VecDeque<Vec<State>>>,
 
     max_history_size: usize,
+    support_virtual_keyboard: bool,
+
+    mouse_buttons_down: Cell<u32>,
+    key_seen_while_mouse_down: Cell<bool>,
 
     modifier_status_provider: &'a dyn ModifierStateProvider,
 }
@@ -85,12 +90,61 @@ impl<'a, State> MatcherMiddleware<'a, State> {
         modifier_status_provider: &'a dyn ModifierStateProvider,
     ) -> Self {
         let max_history_size = options_provider.max_history_size();
+        let support_virtual_keyboard = options_provider.support_virtual_keyboard();
 
         Self {
             matchers,
             matcher_states: RefCell::new(VecDeque::new()),
             max_history_size,
+            support_virtual_keyboard,
+            mouse_buttons_down: Cell::new(0),
+            key_seen_while_mouse_down: Cell::new(false),
             modifier_status_provider,
+        }
+    }
+
+    fn handle_virtual_keyboard_event(&self, event_type: &EventType) -> bool {
+        match event_type {
+            EventType::Mouse(mouse_event) => {
+                match mouse_event.status {
+                    Status::Pressed => {
+                        self.mouse_buttons_down
+                            .set(self.mouse_buttons_down.get().saturating_add(1));
+                    }
+                    Status::Released => {
+                        let buttons_down = self.mouse_buttons_down.get();
+
+                        // Ignore unmatched release events.
+                        if buttons_down == 0 {
+                            return true;
+                        }
+
+                        let remaining = buttons_down - 1;
+                        self.mouse_buttons_down.set(remaining);
+
+                        if remaining == 0 {
+                            if !self.key_seen_while_mouse_down.get() {
+                                trace!(
+                                    "mouse click without keyboard event, clearing matching state"
+                                );
+                                self.matcher_states.borrow_mut().clear();
+                            }
+
+                            self.key_seen_while_mouse_down.set(false);
+                        }
+                    }
+                }
+
+                true
+            }
+            EventType::Keyboard(keyboard_event)
+                if keyboard_event.status == Status::Pressed
+                    && self.mouse_buttons_down.get() > 0 =>
+            {
+                self.key_seen_while_mouse_down.set(true);
+                false
+            }
+            _ => false,
         }
     }
 }
@@ -101,6 +155,10 @@ impl<State> Middleware for MatcherMiddleware<'_, State> {
     }
 
     fn next(&self, event: Event, _: &mut dyn FnMut(Event)) -> Event {
+        if self.support_virtual_keyboard && self.handle_virtual_keyboard_event(&event.etype) {
+            return event;
+        }
+
         if is_event_of_interest(&event.etype) {
             let mut matcher_states = self.matcher_states.borrow_mut();
             let prev_states = if matcher_states.is_empty() {
@@ -247,5 +305,158 @@ fn should_skip_key_event_due_to_modifier_press(modifier_state: &ModifierState) -
         modifier_state.is_alt_down || modifier_state.is_meta_down
     } else {
         unreachable!()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::event::input::{KeyboardEvent, MouseButton, MouseEvent};
+
+    struct TestConfig {
+        support_virtual_keyboard: bool,
+    }
+
+    impl MatcherMiddlewareConfigProvider for TestConfig {
+        fn max_history_size(&self) -> usize {
+            10
+        }
+
+        fn support_virtual_keyboard(&self) -> bool {
+            self.support_virtual_keyboard
+        }
+    }
+
+    struct TestModifierStateProvider;
+
+    impl ModifierStateProvider for TestModifierStateProvider {
+        fn get_modifier_state(&self) -> ModifierState {
+            ModifierState {
+                is_ctrl_down: false,
+                is_alt_down: false,
+                is_meta_down: false,
+            }
+        }
+    }
+
+    struct TestMatcher;
+
+    impl<'a> Matcher<'a, String> for TestMatcher {
+        fn process(
+            &'a self,
+            prev_state: Option<&String>,
+            event: &MatcherEvent,
+        ) -> (String, Vec<MatchResult>) {
+            let mut state = prev_state.cloned().unwrap_or_default();
+
+            if let MatcherEvent::Key {
+                chars: Some(chars), ..
+            } = event
+            {
+                state.push_str(chars);
+            }
+
+            (state, Vec::new())
+        }
+    }
+
+    fn key_event(chars: &str) -> Event {
+        Event {
+            source_id: 0,
+            etype: EventType::Keyboard(KeyboardEvent {
+                key: Key::Other(0),
+                value: Some(chars.to_string()),
+                status: Status::Pressed,
+                variant: None,
+            }),
+        }
+    }
+
+    fn mouse_event(status: Status) -> Event {
+        Event {
+            source_id: 0,
+            etype: EventType::Mouse(MouseEvent {
+                button: MouseButton::Left,
+                status,
+            }),
+        }
+    }
+
+    fn current_state(middleware: &MatcherMiddleware<'_, String>) -> Option<String> {
+        middleware
+            .matcher_states
+            .borrow()
+            .back()
+            .and_then(|states| states.first())
+            .cloned()
+    }
+
+    #[test]
+    fn virtual_keyboard_disabled_keeps_legacy_mouse_invalidation() {
+        let matcher = TestMatcher;
+        let matchers: [&dyn Matcher<'_, String>; 1] = [&matcher];
+        let config = TestConfig {
+            support_virtual_keyboard: false,
+        };
+        let modifiers = TestModifierStateProvider;
+
+        let middleware = MatcherMiddleware::new(&matchers, &config, &modifiers);
+        let mut dispatch = |_| {};
+
+        middleware.next(key_event("a"), &mut dispatch);
+        assert_eq!(current_state(&middleware).as_deref(), Some("a"));
+
+        middleware.next(mouse_event(Status::Pressed), &mut dispatch);
+
+        assert!(middleware.matcher_states.borrow().is_empty());
+    }
+
+    #[test]
+    fn virtual_keyboard_enabled_invalidates_pointer_only_click_on_release() {
+        let matcher = TestMatcher;
+        let matchers: [&dyn Matcher<'_, String>; 1] = [&matcher];
+        let config = TestConfig {
+            support_virtual_keyboard: true,
+        };
+        let modifiers = TestModifierStateProvider;
+
+        let middleware = MatcherMiddleware::new(&matchers, &config, &modifiers);
+        let mut dispatch = |_| {};
+
+        middleware.next(key_event("a"), &mut dispatch);
+
+        middleware.next(mouse_event(Status::Pressed), &mut dispatch);
+
+        // Invalidation is delayed until we know whether the click generated a key.
+        assert_eq!(current_state(&middleware).as_deref(), Some("a"));
+
+        middleware.next(mouse_event(Status::Released), &mut dispatch);
+
+        assert!(middleware.matcher_states.borrow().is_empty());
+    }
+
+    #[test]
+    fn virtual_keyboard_enabled_preserves_state_across_key_clicks() {
+        let matcher = TestMatcher;
+        let matchers: [&dyn Matcher<'_, String>; 1] = [&matcher];
+        let config = TestConfig {
+            support_virtual_keyboard: true,
+        };
+        let modifiers = TestModifierStateProvider;
+
+        let middleware = MatcherMiddleware::new(&matchers, &config, &modifiers);
+        let mut dispatch = |_| {};
+
+        middleware.next(mouse_event(Status::Pressed), &mut dispatch);
+        middleware.next(key_event("a"), &mut dispatch);
+        middleware.next(mouse_event(Status::Released), &mut dispatch);
+
+        assert_eq!(current_state(&middleware).as_deref(), Some("a"));
+
+        middleware.next(mouse_event(Status::Pressed), &mut dispatch);
+        middleware.next(key_event("b"), &mut dispatch);
+        middleware.next(mouse_event(Status::Released), &mut dispatch);
+
+        assert_eq!(current_state(&middleware).as_deref(), Some("ab"));
     }
 }

--- a/espanso/src/cli/worker/config.rs
+++ b/espanso/src/cli/worker/config.rs
@@ -172,6 +172,10 @@ impl espanso_engine::process::MatcherMiddlewareConfigProvider for ConfigManager<
     fn max_history_size(&self) -> usize {
         self.default().backspace_limit()
     }
+
+    fn support_virtual_keyboard(&self) -> bool {
+        self.default().support_virtual_keyboard()
+    }
 }
 
 impl espanso_engine::process::UndoEnabledProvider for ConfigManager<'_> {

--- a/espanso/src/patch/patches/macros.rs
+++ b/espanso/src/patch/patches/macros.rs
@@ -83,6 +83,10 @@ macro_rules! generate_patchable_config {
           self.base.search_shortcut()
         }
 
+        fn support_virtual_keyboard(&self) -> bool {
+          self.base.support_virtual_keyboard()
+        }
+
         fn show_icon(&self) -> bool {
           self.base.show_icon()
         }

--- a/schemas/config.schema.json
+++ b/schemas/config.schema.json
@@ -144,6 +144,11 @@
       "type": "boolean",
       "default": true
     },
+    "support_virtual_keyboard": {
+      "description": "Preserve matcher state for pointer-operated virtual keyboards that emit keyboard events between mouse press and release. Default false.",
+      "type": "boolean",
+      "default": false
+    },
     "apply_patch": {
       "type": "boolean",
       "default": true,


### PR DESCRIPTION
Some on-screen keyboards emit keyboard events while the user presses virtual keys with the pointer.

Espanso currently invalidates the matcher state when a mouse event is received. For pointer-operated virtual keyboards, this means that multi-character triggers cannot be entered because every virtual key click clears the accumulated matcher state.

This PR adds an opt-in `support_virtual_keyboard` setting.

When enabled:
- mouse invalidation is delayed until button release
- if a keyboard press occurred while the mouse button was held, the matcher state is preserved
- a normal pointer click without a keyboard event still invalidates the matcher state

The option defaults to `false`, so existing behavior remains unchanged unless explicitly enabled with support_virtual_keyboard: true

The matcher-side implementation is platform-independent. It has been manually tested on KDE Plasma 6.7 Wayland with a Python-based OSK called Vboard.

Tests were added for:
- preserving the existing mouse invalidation behavior when the option is disabled
- invalidating pointer-only clicks when the option is enabled
- preserving matcher state across multiple virtual-keyboard clicks

The Linux Wayland and X11 test/clippy configurations also pass.

Current limitation: This fix will not work for OSKs that send the key after releasing the mouse button (e.g. Onboard). A simple delay would not reliably fix this, as there may be intermediate pointer interactions such as popup menus - which is the case for Onboard.

Other potential fix to consider: UndoMiddleware has a separate mouse invalidation path: mouse events discard the stored undo record used by undo_backspace. This is deactivated on Wayland so I didn't test that. 

AI disclosure: The fix's implementation was created by AI.