### PR TITLE
feat(search): support dark mode in the search bar and choice popup

### DIFF
--- a/espanso-modulo/src/sys/search/search.cpp
+++ b/espanso-modulo/src/sys/search/search.cpp
@@ -31,6 +31,15 @@
 #include <unordered_map>
 #include <vector>
 
+#ifdef __WXMSW__
+#include <dwmapi.h>
+#include <windows.h>
+#ifndef DWMWA_USE_IMMERSIVE_DARK_MODE
+#define DWMWA_USE_IMMERSIVE_DARK_MODE 20
+#endif
+#pragma comment(lib, "dwmapi.lib")
+#endif
+
 #ifdef __WXOSX__
 // Implemented in search_mac.mm. Returns true if the key window's first
 // responder currently has marked (uncommitted) text from an IME
@@ -56,6 +65,34 @@ const int HELP_TEXT_FONT_SIZE = 10;
 
 const wxColour SELECTION_LIGHT_BG = wxColour(164, 210, 253);
 const wxColour SELECTION_DARK_BG = wxColour(49, 88, 126);
+
+// Dark mode palette, applied when the OS is in dark mode
+const wxColour DARK_MODE_BG = wxColour(30, 30, 30);
+const wxColour DARK_MODE_FG = wxColour(230, 230, 230);
+const wxColour DARK_MODE_HINT_FG = wxColour(160, 160, 160);
+
+#ifdef __WXMSW__
+// On Windows, wxWidgets' GetAppearance() doesn't reflect the OS-level dark
+// mode setting unless the app opts in, so we read it directly from the
+// registry instead. AppsUseLightTheme is 0 when dark mode is enabled.
+bool IsWindowsDarkModeEnabled() {
+    HKEY key;
+    if (RegOpenKeyExW(HKEY_CURRENT_USER,
+                      L"Software\\Microsoft\\Windows\\CurrentVersion\\Themes\\Personalize",
+                      0, KEY_READ, &key) != ERROR_SUCCESS) {
+        return false;
+    }
+
+    DWORD value = 1; // Default to light mode when the value is missing
+    DWORD size = sizeof(value);
+    LONG result = RegQueryValueExW(key, L"AppsUseLightTheme", nullptr, nullptr,
+                                   reinterpret_cast<LPBYTE>(&value), &size);
+    RegCloseKey(key);
+
+    // 0 => dark mode, 1 => light mode
+    return result == ERROR_SUCCESS && value == 0;
+}
+#endif
 
 // https://docs.wxwidgets.org/stable/classwx_frame.html
 const int MIN_WIDTH = 500;
@@ -210,6 +247,11 @@ SearchFrame::SearchFrame(const wxString &title, const wxPoint &pos,
     unsigned int fgSum = (fg.Red() + fg.Blue() + fg.Green());
     bool isDark = fgSum > bgSum;
 #endif
+#ifdef __WXMSW__
+    // wxSystemSettings::GetAppearance() doesn't detect dark mode on Windows
+    // unless the app opts in, so read the OS setting from the registry.
+    isDark = IsWindowsDarkModeEnabled();
+#endif
 
     panel = new wxPanel(this, wxID_ANY);
     wxBoxSizer *vbox = new wxBoxSizer(wxVERTICAL);
@@ -260,6 +302,26 @@ SearchFrame::SearchFrame(const wxString &title, const wxPoint &pos,
     resultBox = new ResultListBox(panel, isDark, resultId, wxDefaultPosition,
                                   wxSize(MIN_WIDTH, MIN_HEIGHT));
     vbox->Add(resultBox, 5, wxEXPAND | wxALL, 0);
+
+    // Follow the device's dark mode preference by styling the window with
+    // dark colors when the system is in dark mode.
+    if (isDark) {
+        SetBackgroundColour(DARK_MODE_BG);
+        panel->SetBackgroundColour(DARK_MODE_BG);
+        searchBar->SetBackgroundColour(DARK_MODE_BG);
+        searchBar->SetForegroundColour(DARK_MODE_FG);
+        if (helpText != nullptr) {
+            helpText->SetForegroundColour(DARK_MODE_HINT_FG);
+        }
+        resultBox->SetBackgroundColour(DARK_MODE_BG);
+#ifdef __WXMSW__
+        // Darken the title bar as well (supported on Windows 10 1809+)
+        HWND hwnd = GetHWND();
+        BOOL dark = TRUE;
+        DwmSetWindowAttribute(hwnd, DWMWA_USE_IMMERSIVE_DARK_MODE, &dark,
+                              sizeof(dark));
+#endif
+    }
 
     Bind(wxEVT_CHAR_HOOK, &SearchFrame::OnCharEvent, this, wxID_ANY);
     searchBar->Bind(wxEVT_CHAR, &SearchFrame::OnCharEvent, this, wxID_ANY);


### PR DESCRIPTION
## Summary

The search popup (used by both the **alt+space search bar** and the **`:choice` extension**) now follows the device's dark mode preference. When the OS is in dark mode, the popup renders with a dark palette instead of a light one.

This addresses the root cause: on Windows, wxWidgets 3.1.5's `wxSystemSettings::GetAppearance().IsDark()` never reports dark mode, because `GetAppearance()` is a stub that falls back to system colors, which stay light for apps that haven't opted into dark mode. As a result the existing `isDark` flag was always `false` on Windows and the popup always rendered light.

## Changes

- **Windows dark-mode detection**: read the `AppsUseLightTheme` registry value under `HKCU\Software\Microsoft\Windows\CurrentVersion\Themes\Personalize` (0 = dark), overriding the ineffective `GetAppearance()` check on Windows only. macOS/Linux detection is unchanged (it already works there).
- **Dark styling** when dark mode is active: dark background (`#1e1e1e`) for the window, panel, text field and result list; light text; gray hint text; and the title bar is darkened via the DWM `DWMWA_USE_IMMERSIVE_DARK_MODE` attribute (Windows 10 1809+, best-effort/ignored on older systems).

## Testing

- `cargo build` (full workspace, MSVC) — passes
- `cargo test --workspace` — all tests pass
- `cargo fmt --all --check` — passes
- Manually verified on Windows 11: popup renders dark in OS dark mode and light in OS light mode, for both the search bar and a `:choice` match.