### PR TITLE
fix(form): don't crash when the form is dismissed

### DIFF
--- a/espanso-modulo/src/sys/form/mod.rs
+++ b/espanso-modulo/src/sys/form/mod.rs
@@ -378,7 +378,15 @@ pub fn show(form: types::Form) -> HashMap<String, String> {
     let mut value_map: HashMap<String, String> = HashMap::new();
 
     extern "C" fn callback(values: *const ValuePair, size: c_int, map: *mut c_void) {
-        let values: &[ValuePair] = unsafe { std::slice::from_raw_parts(values, size as usize) };
+        // When the form is canceled (Escape or the close button), the C++ side
+        // invokes the callback with an empty vector, whose `data()` is null.
+        // Creating a slice from a null pointer is UB (and panics in debug
+        // builds), so guard against it and treat it as an empty result.
+        let values: &[ValuePair] = if size <= 0 || values.is_null() {
+            &[]
+        } else {
+            unsafe { std::slice::from_raw_parts(values, size as usize) }
+        };
         let map = map as *mut HashMap<String, String>;
         let map = unsafe { &mut (*map) };
         for pair in values {


### PR DESCRIPTION
## Summary

Dismissing a form (pressing **Escape** or clicking the **X**) currently crashes the modulo process with a Rust panic in debug builds, surfacing an error to the user instead of silently canceling the match.

## Root cause

When the form is dismissed without submitting, the C++ side invokes the result callback with an **empty** `std::vector`, whose `data()` returns `nullptr`. The Rust callback then creates a slice with `std::slice::from_raw_parts(null_ptr, 0)`, which is undefined behavior: a slice pointer must be non-null even for zero-length slices.

In debug builds, Rust's "unsafe precondition" check panics (killing the modulo process → `modulo exited with non-zero status code` → `modulo returned an empty output` → rendering error). Release builds compile the check out, so the bug only manifests as a crash in dev/debug builds, but it's UB in all builds.

## Changes

- `espanso-modulo/src/sys/form/mod.rs`: guard the FFI callback — when the pointer is null or the size is 0, use an empty slice instead of `from_raw_parts`. The empty result then flows through the existing cancel path (`{}` → `Ok(None)` → `Aborted` → no-op), matching the behavior of canceling the search bar/choice popup.

## Testing

- `cargo build` (full workspace, MSVC) — passes
- `cargo test --workspace` — all tests pass
- Manually verified on Windows 11 with a debug build: dismissing a form via Escape or the close button no longer logs an error and nothing is injected; submitting still works.