### PR TITLE
fix(linux): start espanso with systemd graphical-session, not default.target

### DIFF
--- a/espanso/src/res/linux/systemd.service
+++ b/espanso/src/res/linux/systemd.service
@@ -1,10 +1,24 @@
 [Unit]
 Description=espanso
+# Order the start after the graphical session: the display server may not be
+# reachable yet when default.target is reached, which made the worker panic
+# with "failed to initialize detector module" (exit status 101) and cycle
+# via Restart=on-failure until the display appeared.
+After=graphical-session.target
+# Stop espanso when the graphical session stops, so it does not outlive
+# logout as an orphaned daemon.
+PartOf=graphical-session.target
 
 [Service]
 ExecStart={{{espanso_path}}} launcher 
 Restart=on-failure
 RestartSec=3
+# A slow boot can exceed the default restart budget (5 starts within 10s),
+# after which systemd marks the unit failed and gives up until manual reset.
+# Widen the budget so slow displays never permanently disable espanso.
+StartLimitIntervalSec=60
+StartLimitBurst=10
 
 [Install]
+# Start with the graphical session instead of racing the display server.
 WantedBy=graphical-session.target

--- a/espanso/src/res/linux/systemd.service
+++ b/espanso/src/res/linux/systemd.service
@@ -8,16 +8,16 @@ After=graphical-session.target
 # Stop espanso when the graphical session stops, so it does not outlive
 # logout as an orphaned daemon.
 PartOf=graphical-session.target
-
-[Service]
-ExecStart={{{espanso_path}}} launcher 
-Restart=on-failure
-RestartSec=3
 # A slow boot can exceed the default restart budget (5 starts within 10s),
 # after which systemd marks the unit failed and gives up until manual reset.
 # Widen the budget so slow displays never permanently disable espanso.
 StartLimitIntervalSec=60
 StartLimitBurst=10
+
+[Service]
+ExecStart={{{espanso_path}}} launcher 
+Restart=on-failure
+RestartSec=3
 
 [Install]
 # Start with the graphical session instead of racing the display server.

--- a/espanso/src/res/linux/systemd.service
+++ b/espanso/src/res/linux/systemd.service
@@ -7,5 +7,4 @@ Restart=on-failure
 RestartSec=3
 
 [Install]
-WantedBy=default.target
-
+WantedBy=graphical-session.target

--- a/espanso/src/res/linux/systemd.service
+++ b/espanso/src/res/linux/systemd.service
@@ -1,18 +1,13 @@
 [Unit]
 Description=espanso
 # Order the start after the graphical session: the display server may not be
-# reachable yet when default.target is reached, which made the worker panic
-# with "failed to initialize detector module" (exit status 101) and cycle
-# via Restart=on-failure until the display appeared.
+# reachable yet while graphical-session.target is starting, which would make
+# the worker panic with "failed to initialize detector module" (exit status
+# 101) and cycle via Restart=on-failure until the display appeared.
 After=graphical-session.target
 # Stop espanso when the graphical session stops, so it does not outlive
 # logout as an orphaned daemon.
 PartOf=graphical-session.target
-# A slow boot can exceed the default restart budget (5 starts within 10s),
-# after which systemd marks the unit failed and gives up until manual reset.
-# Widen the budget so slow displays never permanently disable espanso.
-StartLimitIntervalSec=60
-StartLimitBurst=10
 
 [Service]
 ExecStart={{{espanso_path}}} launcher 


### PR DESCRIPTION
### Issue for this PR

Closes #2792

### Type of change

- [x] Bug fix

### What does this PR do?

Updates the shipped Linux systemd unit (`espanso/src/res/linux/systemd.service`) so espanso is tied to the graphical session instead of racing the display server. Each change is commented inline in the unit:

```diff
 [Unit]
 Description=espanso
+# Order the start after the graphical session: the display server may not be
+# reachable yet while graphical-session.target is starting, which would make
+# the worker panic with "failed to initialize detector module" (exit status
+# 101) and cycle via Restart=on-failure until the display appeared.
+After=graphical-session.target
+# Stop espanso when the graphical session stops, so it does not outlive
+# logout as an orphaned daemon.
+PartOf=graphical-session.target
 
 [Service]
 ExecStart={{{espanso_path}}} launcher 
 Restart=on-failure
 RestartSec=3
 
 [Install]
+# Start with the graphical session instead of racing the display server.
-WantedBy=default.target
+WantedBy=graphical-session.target
```

- `WantedBy=graphical-session.target` (closes #2792): `default.target` is reached before the display server. On X11 systems the worker connects to the display at startup; starting too early makes it panic (`failed to initialize detector module: detection source initialization failed`, `espanso/src/cli/worker/engine/mod.rs:146` → exit status 101), and `Restart=on-failure` cycles the unit every 3 seconds until the display finally appears — 4 starts on one observed boot, 3 of them panics.
- `After=graphical-session.target`: explicit ordering so the start happens after the session target is reached, not concurrently with it.
- `PartOf=graphical-session.target`: stop espanso when the graphical session stops, so it does not outlive logout as an orphaned daemon.

Related: #2791 (AppImage FUSE mount leaks — the restart cycle above is what leaves dead `/tmp/.mount_espans*` mounts behind; this PR removes the trigger, #2791 removes the leak mechanism).

### How did you verify your code works?

- Reproduced the failure mode on Arch (systemd 261): `journalctl --user -u espanso` shows the 3× `status=101` panic cycle at boot before the display is up, with the exact panic chain quoted in #2792.
- Verified the fixed ordering locally with a user-level override (`add-wants graphical-session.target` + `After=graphical-session.target` drop-in): the unit starts once, after the session, with no panics.
- `systemd-analyze --user verify` on the rendered unit (with `{{{espanso_path}}}` substituted): clean. This check caught an earlier iteration of this PR that placed `StartLimitIntervalSec`/`StartLimitBurst` in `[Service]` ("Unknown key ... ignoring") — both keys belong in `[Unit]`.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR