### PR TITLE
fix(detect): report X11 hotkey registration failures with hotkey name

### DIFF
--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -223,10 +223,12 @@ impl Source for X11Source {
             let raw = convert_hotkey_to_raw(hk);
             if let Some(raw_hk) = raw {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
-                // Any failing lock-mask variant sets error_code, so the warning
-                // can fire even when the plain combo registered fine; the hint
-                // covers the still-works case.
-                if result.error_code != 0 {
+                if result.success == 0 {
+                    error!("unable to register hotkey: {}", hk);
+                } else if result.error_code != 0 {
+                    // Any failing lock-mask variant sets error_code, so the warning
+                    // can fire even when the plain combo registered fine; the hint
+                    // covers the still-works case.
                     let hint = if result.error_code == BAD_ACCESS {
                         "; the shortcut will still work but may also trigger that application"
                     } else {
@@ -245,7 +247,10 @@ impl Source for X11Source {
                 }
                 // The mapping is inserted even when the grab failed: XRecord-based
                 // detection is unaffected by grab ownership, so the hotkey keeps working.
-                raw_hotkey_mapping.insert((result.key_code, result.state), hk.id);
+                // It is skipped only when no keycode resolved (success 0).
+                if result.success != 0 {
+                    raw_hotkey_mapping.insert((result.key_code, result.state), hk.id);
+                }
             } else {
                 error!("unable to generate raw hotkey mapping: {}", hk);
             }

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -224,7 +224,10 @@ impl Source for X11Source {
             if let Some(raw_hk) = raw {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
                 if result.success == 0 {
-                    error!("unable to register hotkey: {}", hk);
+                    error!(
+                        "no keycode resolved for hotkey: {}; it will not be registered",
+                        hk
+                    );
                 } else if result.error_code != 0 {
                     // Any failing lock-mask variant sets error_code, so the warning
                     // can fire even when the plain combo registered fine; the hint

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -136,6 +136,8 @@ fn x11_request_name(code: i32) -> String {
     }
 }
 
+const BAD_ACCESS: i32 = 10;
+
 #[allow(improper_ctypes)]
 #[link(name = "espansodetect", kind = "static")]
 extern "C" {
@@ -221,8 +223,11 @@ impl Source for X11Source {
             let raw = convert_hotkey_to_raw(hk);
             if let Some(raw_hk) = raw {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
+                // Any failing lock-mask variant sets error_code, so the warning
+                // can fire even when the plain combo registered fine; the hint
+                // covers the still-works case.
                 if result.error_code != 0 {
-                    let hint = if result.error_code == 10 {
+                    let hint = if result.error_code == BAD_ACCESS {
                         "; the shortcut will still work but may also trigger that application"
                     } else {
                         ""
@@ -594,5 +599,19 @@ mod tests {
         let result: Option<InputEvent> =
             convert_raw_input_event_to_input_event(raw, &HashMap::new(), 0);
         assert!(result.is_none());
+    }
+
+    #[test]
+    fn x11_error_name_translates_known_codes() {
+        assert_eq!(x11_error_name(10), "BadAccess");
+        assert_eq!(x11_error_name(1), "BadRequest");
+        assert_eq!(x11_error_name(17), "BadImplementation");
+        assert_eq!(x11_error_name(999), "code 999");
+    }
+
+    #[test]
+    fn x11_request_name_translates_known_opcodes() {
+        assert_eq!(x11_request_name(33), "X_GrabKey");
+        assert_eq!(x11_request_name(99), "request 99");
     }
 }

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -223,7 +223,7 @@ impl Source for X11Source {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
                 if result.error_code != 0 {
                     let hint = if result.error_code == 10 {
-                        "; the shortcut may conflict with another application"
+                        "; the shortcut will still work but may also trigger that application"
                     } else {
                         ""
                     };

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -100,6 +100,7 @@ pub struct RawHotKeyResult {
     pub success: i32,
     pub key_code: i32,
     pub state: u32,
+    pub error_code: i32,
 }
 
 #[allow(improper_ctypes)]
@@ -187,12 +188,16 @@ impl Source for X11Source {
             let raw = convert_hotkey_to_raw(hk);
             if let Some(raw_hk) = raw {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
-                if result.success == 0 {
-                    error!("unable to register hotkey: {}", hk);
-                } else {
-                    raw_hotkey_mapping.insert((result.key_code, result.state), hk.id);
-                    debug!("registered hotkey: {}", hk);
+                if result.error_code != 0 {
+                    warn!(
+                        "unable to register hotkey: {} (X11 error code: {}); the shortcut may conflict with another application",
+                        hk, result.error_code
+                    );
                 }
+                // The mapping is inserted even when the grab failed: XRecord-based
+                // detection is unaffected by grab ownership, so the hotkey keeps working.
+                raw_hotkey_mapping.insert((result.key_code, result.state), hk.id);
+                debug!("registered hotkey: {}", hk);
             } else {
                 error!("unable to generate raw hotkey mapping: {}", hk);
             }

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -101,6 +101,39 @@ pub struct RawHotKeyResult {
     pub key_code: i32,
     pub state: u32,
     pub error_code: i32,
+    pub error_request_code: i32,
+}
+
+// X11 protocol error-code names (Xlib); unknown codes fall back to the raw
+// number.
+fn x11_error_name(code: i32) -> String {
+    match code {
+        1 => "BadRequest".to_string(),
+        2 => "BadValue".to_string(),
+        3 => "BadWindow".to_string(),
+        4 => "BadPixmap".to_string(),
+        5 => "BadAtom".to_string(),
+        6 => "BadCursor".to_string(),
+        7 => "BadFont".to_string(),
+        8 => "BadMatch".to_string(),
+        9 => "BadDrawable".to_string(),
+        10 => "BadAccess".to_string(),
+        11 => "BadAlloc".to_string(),
+        12 => "BadColor".to_string(),
+        13 => "BadGC".to_string(),
+        14 => "BadIDChoice".to_string(),
+        15 => "BadName".to_string(),
+        16 => "BadLength".to_string(),
+        17 => "BadImplementation".to_string(),
+        _ => format!("code {}", code),
+    }
+}
+
+fn x11_request_name(code: i32) -> String {
+    match code {
+        33 => "X_GrabKey".to_string(),
+        _ => format!("request {}", code),
+    }
 }
 
 #[allow(improper_ctypes)]
@@ -189,9 +222,18 @@ impl Source for X11Source {
             if let Some(raw_hk) = raw {
                 let result = unsafe { detect_register_hotkey(handle, raw_hk, mod_indexes) };
                 if result.error_code != 0 {
+                    let hint = if result.error_code == 10 {
+                        "; the shortcut may conflict with another application"
+                    } else {
+                        ""
+                    };
                     warn!(
-                        "unable to register hotkey: {} (X11 error code: {}); the shortcut may conflict with another application",
-                        hk, result.error_code
+                        "unable to register hotkey: {} (X11 error {}: {} on {}){}",
+                        hk,
+                        result.error_code,
+                        x11_error_name(result.error_code),
+                        x11_request_name(result.error_request_code),
+                        hint
                     );
                 } else {
                     debug!("registered hotkey: {}", hk);

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -193,11 +193,12 @@ impl Source for X11Source {
                         "unable to register hotkey: {} (X11 error code: {}); the shortcut may conflict with another application",
                         hk, result.error_code
                     );
+                } else {
+                    debug!("registered hotkey: {}", hk);
                 }
                 // The mapping is inserted even when the grab failed: XRecord-based
                 // detection is unaffected by grab ownership, so the hotkey keeps working.
                 raw_hotkey_mapping.insert((result.key_code, result.state), hk.id);
-                debug!("registered hotkey: {}", hk);
             } else {
                 error!("unable to generate raw hotkey mapping: {}", hk);
             }

--- a/espanso-detect/src/x11/native.cpp
+++ b/espanso-detect/src/x11/native.cpp
@@ -78,6 +78,10 @@ int detect_error_callback(Display *display, XErrorEvent *error);
 // X protocol errors are delivered asynchronously through the current error
 // handler (not as XGrabKey's return value), so a request-scoped handler is
 // installed around hotkey registration to detect BadAccess reliably.
+// Registration is single-threaded (worker init, one X11Source); these
+// request-scoped statics are not safe for concurrent use. The handler
+// overwrites the codes, so with multiple failing grabs only the most recent
+// error is reported — adequate for a warning.
 static int grab_error_code = 0;
 static int grab_error_request_code = 0;
 static int detect_grab_error_handler(Display *, XErrorEvent *error) {

--- a/espanso-detect/src/x11/native.cpp
+++ b/espanso-detect/src/x11/native.cpp
@@ -75,6 +75,15 @@ typedef struct {
 void detect_event_callback(XPointer, XRecordInterceptData *);
 int detect_error_callback(Display *display, XErrorEvent *error);
 
+// X protocol errors are delivered asynchronously through the current error
+// handler (not as XGrabKey's return value), so a request-scoped handler is
+// installed around hotkey registration to detect BadAccess reliably.
+static int grab_error_code = 0;
+static int detect_grab_error_handler(Display *, XErrorEvent *error) {
+  grab_error_code = error->error_code;
+  return 0;
+}
+
 int32_t detect_check_x11() {
     Display *check_disp = XOpenDisplay(NULL);
 
@@ -230,6 +239,9 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
     // We need to register an hotkey for all combinations of "useless"
     // modifiers, such as the NumLock, as the XGrabKey method wants an exact
     // match.
+    grab_error_code = 0;
+    XErrorHandler previous_handler = XSetErrorHandler(&detect_grab_error_handler);
+
     for (uint state = 0; state < 256; state++) {
         // Check if the current state includes a "useless modifier" but none of
         // the valid ones
@@ -237,12 +249,18 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
             (state & valid_modifiers) == 0) {
             uint final_modifiers = state | target_modifiers;
 
-            int res = XGrabKey(context->ctrl_disp, key_code, final_modifiers,
+            XGrabKey(context->ctrl_disp, key_code, final_modifiers,
                                root, False, GrabModeAsync, GrabModeAsync);
-            if (res == BadAccess || res == BadValue) {
-                result.success = 0;
-            }
         }
+    }
+
+    // Force delivery of any asynchronous BadAccess errors collected above;
+    // XGrabKey's return value does not report them.
+    XSync(context->ctrl_disp, False);
+    XSetErrorHandler(previous_handler);
+
+    if (grab_error_code != 0) {
+        result.success = 0;
     }
 
     return result;

--- a/espanso-detect/src/x11/native.cpp
+++ b/espanso-detect/src/x11/native.cpp
@@ -79,8 +79,10 @@ int detect_error_callback(Display *display, XErrorEvent *error);
 // handler (not as XGrabKey's return value), so a request-scoped handler is
 // installed around hotkey registration to detect BadAccess reliably.
 static int grab_error_code = 0;
+static int grab_error_request_code = 0;
 static int detect_grab_error_handler(Display *, XErrorEvent *error) {
     grab_error_code = error->error_code;
+    grab_error_request_code = error->request_code;
     return 0;
 }
 
@@ -240,6 +242,7 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
     // modifiers, such as the NumLock, as the XGrabKey method wants an exact
     // match.
     grab_error_code = 0;
+    grab_error_request_code = 0;
     XErrorHandler previous_handler =
         XSetErrorHandler(&detect_grab_error_handler);
 
@@ -264,6 +267,7 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
     // regardless of grab ownership, and dropping the hotkey would silently
     // disable a working shortcut.
     result.error_code = grab_error_code;
+    result.error_request_code = grab_error_request_code;
 
     return result;
 }

--- a/espanso-detect/src/x11/native.cpp
+++ b/espanso-detect/src/x11/native.cpp
@@ -80,8 +80,8 @@ int detect_error_callback(Display *display, XErrorEvent *error);
 // installed around hotkey registration to detect BadAccess reliably.
 static int grab_error_code = 0;
 static int detect_grab_error_handler(Display *, XErrorEvent *error) {
-  grab_error_code = error->error_code;
-  return 0;
+    grab_error_code = error->error_code;
+    return 0;
 }
 
 int32_t detect_check_x11() {
@@ -240,7 +240,8 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
     // modifiers, such as the NumLock, as the XGrabKey method wants an exact
     // match.
     grab_error_code = 0;
-    XErrorHandler previous_handler = XSetErrorHandler(&detect_grab_error_handler);
+    XErrorHandler previous_handler =
+        XSetErrorHandler(&detect_grab_error_handler);
 
     for (uint state = 0; state < 256; state++) {
         // Check if the current state includes a "useless modifier" but none of
@@ -249,8 +250,8 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
             (state & valid_modifiers) == 0) {
             uint final_modifiers = state | target_modifiers;
 
-            XGrabKey(context->ctrl_disp, key_code, final_modifiers,
-                               root, False, GrabModeAsync, GrabModeAsync);
+            XGrabKey(context->ctrl_disp, key_code, final_modifiers, root, False,
+                     GrabModeAsync, GrabModeAsync);
         }
     }
 

--- a/espanso-detect/src/x11/native.cpp
+++ b/espanso-detect/src/x11/native.cpp
@@ -259,9 +259,10 @@ HotKeyResult detect_register_hotkey(void *_context, HotKeyRequest request,
     XSync(context->ctrl_disp, False);
     XSetErrorHandler(previous_handler);
 
-    if (grab_error_code != 0) {
-        result.success = 0;
-    }
+    // Report the error without failing: XRecord-based detection works
+    // regardless of grab ownership, and dropping the hotkey would silently
+    // disable a working shortcut.
+    result.error_code = grab_error_code;
 
     return result;
 }

--- a/espanso-detect/src/x11/native.h
+++ b/espanso-detect/src/x11/native.h
@@ -68,8 +68,9 @@ typedef struct {
     // registration (0 = no error). minor_code is omitted: it is always 0 for
     // core-protocol requests such as X_GrabKey. The grab may still have failed
     // for some modifier variants even when success is 1; XRecord-based
-    // detection is unaffected by grab failures. success is retained for
-    // struct-layout compatibility only: consumers rely on error_code.
+    // detection is unaffected by grab failures. success is 0 only when no
+    // keycode could be resolved (nothing was registered); grab failures
+    // keep success 1 with error_code set.
     int32_t error_code;
     int32_t error_request_code;
 } HotKeyResult;

--- a/espanso-detect/src/x11/native.h
+++ b/espanso-detect/src/x11/native.h
@@ -64,10 +64,13 @@ typedef struct {
     int32_t success;
     int32_t key_code;
     uint32_t state;
-    // X11 error code reported during registration (0 = no error). The grab
-    // may still have failed for some modifier variants even when success is 1;
-    // XRecord-based detection is unaffected by grab failures.
+    // X11 error code and the failing request opcode reported during
+    // registration (0 = no error). minor_code is omitted: it is always 0 for
+    // core-protocol requests such as X_GrabKey. The grab may still have failed
+    // for some modifier variants even when success is 1; XRecord-based
+    // detection is unaffected by grab failures.
     int32_t error_code;
+    int32_t error_request_code;
 } HotKeyResult;
 
 typedef struct {

--- a/espanso-detect/src/x11/native.h
+++ b/espanso-detect/src/x11/native.h
@@ -64,6 +64,10 @@ typedef struct {
     int32_t success;
     int32_t key_code;
     uint32_t state;
+    // X11 error code reported during registration (0 = no error). The grab
+    // may still have failed for some modifier variants even when success is 1;
+    // XRecord-based detection is unaffected by grab failures.
+    int32_t error_code;
 } HotKeyResult;
 
 typedef struct {

--- a/espanso-detect/src/x11/native.h
+++ b/espanso-detect/src/x11/native.h
@@ -68,7 +68,8 @@ typedef struct {
     // registration (0 = no error). minor_code is omitted: it is always 0 for
     // core-protocol requests such as X_GrabKey. The grab may still have failed
     // for some modifier variants even when success is 1; XRecord-based
-    // detection is unaffected by grab failures.
+    // detection is unaffected by grab failures. success is retained for
+    // struct-layout compatibility only: consumers rely on error_code.
     int32_t error_code;
     int32_t error_request_code;
 } HotKeyResult;


### PR DESCRIPTION
### Related issue

Found while investigating #2791 (same X11/AppImage investigation; this PR implements the missing hotkey-name logging that came up there).

### Type of change

- [x] Bug fix

### What does this PR do?

On X11, `XGrabKey` reports `BadAccess` asynchronously through the error handler — never through its return value. `detect_register_hotkey` checked the return value (`res == BadAccess`), which is dead code, so a conflicting hotkey produced anonymous X11 error lines and the existing `unable to register hotkey` log never fired.

This PR makes `detect_register_hotkey` install a request-scoped error handler and call `XSync`, capturing the actual error code and the failing request opcode; `HotKeyResult`/`RawHotKeyResult` gain `error_code` and `error_request_code` fields. The Rust side now logs a warning naming the hotkey with the error and request translated to protocol names (e.g. `BadAccess` on `X_GrabKey`), and always inserts the mapping (XRecord-based detection does not depend on grab ownership, so a conflicted hotkey keeps working).

> **No behavior change.** In 2.4.1 the `res == BadAccess` check is dead code (`XGrabKey` reports `BadAccess` only through the error handler, never as a return value), so conflicted hotkeys already kept working through XRecord. This PR changes only the logging: the behavior existed before — it was just invisible.

**Before** — four anonymous lines, no hotkey name (espanso 2.4.1 AppImage, journal, 2026-09-02):

```
2026-09-02T14:27:41+07:00 svelte espanso[3811]: X11 Reported an error, code: 10, request_code: 33, minor_code: 0
2026-09-02T14:27:41+07:00 svelte espanso[3811]: X11 Reported an error, code: 10, request_code: 33, minor_code: 0
2026-09-02T14:27:41+07:00 svelte espanso[3811]: X11 Reported an error, code: 10, request_code: 33, minor_code: 0
2026-09-02T14:27:41+07:00 svelte espanso[3811]: X11 Reported an error, code: 10, request_code: 33, minor_code: 0
```

**After** — those four anonymous lines are replaced by a single warning naming the hotkey, the error, and the failing request (journal):

```
11:00:14 [worker(3968830)] [WARN] unable to register hotkey: ALT+SPACE (X11 error 10: BadAccess on X_GrabKey); the shortcut will still work but may also trigger that application
```

(The conflicting combo here is the built-in search shortcut, ALT+SPACE.)

### Error translation

The reported numbers are X protocol identifiers, translated programmatically on the Rust side:

- `error_code` → error name (`10` → `BadAccess`, `8` → `BadMatch`, …): the first 17 core-protocol error codes are mapped to their Xlib names; unknown codes fall back to the raw number.
- `error_request_code` → request name (`33` → `X_GrabKey`, …): the request opcode from `XErrorEvent`, so the message names the call that failed even if registration is later extended beyond `XGrabKey`. Unknown opcodes fall back to `request N`.
- `minor_code` is not captured: for core-protocol requests like `X_GrabKey` it is structurally always `0`, so it carries no information.

The conflict hint is attached only when the error is `BadAccess` — that is the one error meaning "another client owns the grab". Other errors mean a different problem, and the hint would mislead. The log level is `warn` rather than `error` because the mapping is always inserted and XRecord-based detection does not need grab ownership: the hotkey is degraded (it may not fire exclusively) but keeps working, so the condition is not fatal. (The original code paired `error!` with skipping the mapping — silently disabling a working shortcut.)

If maintainers would rather make exclusivity opt-in (e.g. a hotkey option like `exclusive = true` that drops the mapping on `BadAccess`), that would be a separate PR — `error_code` is already plumbed through the FFI. Happy to open one if there's interest.

### How did you verify your code works?

- `cargo build -p espanso-detect` and `cargo build -p espanso` green; `clang-format --dry-run -Werror` clean.
- Live run on X11 with a conflicting ALT+SPACE grab: the WARN line above, followed immediately by `using X11ProxyInjector` / `using X11Clipboard` — the worker continued and the search shortcut still works, because the mapping is always inserted.

### Checklist

- [x] I have tested my changes locally
- [x] I have not included unrelated changes in this PR