### PR TITLE
fix(x11): log NUL-producing keys at trace instead of warn

### DIFF
--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -318,12 +318,14 @@ fn convert_raw_input_event_to_input_event(
                         }
                     }
                     Err(err) => {
-                        // A lone NUL byte is what XLookupString returns for
-                        // NUL-producing keys (e.g. Ctrl-Space): legitimate
-                        // input, not corruption. Longer interiors cannot come
-                        // from well-formed detector output, so keep those loud.
+                        // XLookupString(3): with the Control modifier on, the
+                        // KeySym is mapped "to an ASCII control character, and
+                        // that character is stored in the buffer" — so a lone
+                        // NUL byte (e.g. Ctrl-Space) is legitimate input, not
+                        // corruption. Longer interiors cannot come from
+                        // well-formed detector output, so keep those loud.
                         if raw.buffer_len == 1 {
-                            trace!("Received malformed char: {}", err);
+                            trace!("NUL-producing key, no text to convert");
                         } else {
                             warn!("Received malformed char: {}", err);
                         }

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -318,7 +318,15 @@ fn convert_raw_input_event_to_input_event(
                         }
                     }
                     Err(err) => {
-                        trace!("Received malformed char: {}", err);
+                        // A lone NUL byte is what XLookupString returns for
+                        // NUL-producing keys (e.g. Ctrl-Space): legitimate
+                        // input, not corruption. Longer interiors cannot come
+                        // from well-formed detector output, so keep those loud.
+                        if raw.buffer_len == 1 {
+                            trace!("Received malformed char: {}", err);
+                        } else {
+                            warn!("Received malformed char: {}", err);
+                        }
                         None
                     }
                 }
@@ -447,7 +455,9 @@ fn raw_to_mouse_button(raw: i32) -> Option<MouseButton> {
 
 #[cfg(test)]
 mod tests {
+    use log::{Level, LevelFilter, Log, Metadata, Record};
     use std::ffi::CString;
+    use std::sync::{Mutex, OnceLock};
 
     use super::*;
 
@@ -539,36 +549,56 @@ mod tests {
         assert!(result.unwrap().into_keyboard().unwrap().value.is_none());
     }
 
-    #[test]
-    fn nul_key_does_not_warn() {
-        use log::{Level, LevelFilter, Log, Metadata, Record};
-        use std::sync::{Mutex, OnceLock};
+    #[derive(Default)]
+    struct Capture {
+        records: Mutex<Vec<(std::thread::ThreadId, Level)>>,
+    }
 
-        struct Capture {
-            records: Mutex<Vec<(std::thread::ThreadId, Level)>>,
-        }
-        impl Log for Capture {
-            fn enabled(&self, _: &Metadata) -> bool {
-                true
-            }
-            fn log(&self, record: &Record) {
-                self.records.lock().unwrap().push((
-                    std::thread::current().id(),
-                    record.level(),
-                ));
-            }
-            fn flush(&self) {}
+    impl Log for Capture {
+        fn enabled(&self, _: &Metadata) -> bool { true }
+
+        fn log(&self, record: &Record) {
+            let thread = std::thread::current().id();
+            let level = record.level();
+            self.records.lock().unwrap().push((thread, level));
         }
 
-        static LOGGER: OnceLock<Capture> = OnceLock::new();
-        let logger = LOGGER.get_or_init(|| Capture {
-            records: Mutex::new(Vec::new()),
-        });
-        // A logger can only be set once per test process; reuse it if so.
+        fn flush(&self) {}
+    }
+
+    static LOGGER: OnceLock<Capture> = OnceLock::new();
+
+    /// Installs the thread-filtered capturing logger (once per test
+    /// process) and drops records captured so far. Assertions filter to
+    /// the calling thread, so tests stay independent despite cargo
+    /// running them on multiple threads. Raising the global max level is
+    /// harmless to the other tests: none of them assert on logs, and this
+    /// is the only `set_logger` call in the crate, so capture cannot be
+    /// silently stolen by a foreign logger.
+    fn capture_thread_logs() {
+        let logger = LOGGER.get_or_init(Capture::default);
         let _ = log::set_logger(logger);
         log::set_max_level(LevelFilter::Trace);
-
         logger.records.lock().unwrap().clear();
+    }
+
+    /// True if the calling thread logged at `min_level` or above since
+    /// the last `capture_thread_logs` call.
+    fn thread_logged_at_or_above(min_level: Level) -> bool {
+        let me = std::thread::current().id();
+        LOGGER
+            .get()
+            .unwrap()
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(thread, level)| thread == &me && *level >= min_level)
+    }
+
+    #[test]
+    fn nul_key_does_not_warn() {
+        capture_thread_logs();
 
         // NUL-producing key (e.g. Ctrl-Space): XLookupString returns a
         // single NUL byte. This is legitimate input, not corruption.
@@ -581,20 +611,27 @@ mod tests {
         let result: Option<InputEvent> =
             convert_raw_input_event_to_input_event(raw, &HashMap::new(), 0);
         assert!(result.unwrap().into_keyboard().unwrap().value.is_none());
+        assert!(!thread_logged_at_or_above(Level::Warn));
+    }
 
-        // Other tests log on their own threads; only records from this
-        // thread belong to the conversion above.
-        let me = std::thread::current().id();
-        let warned = logger
-            .records
-            .lock()
-            .unwrap()
-            .iter()
-            .any(|(thread, level)| thread == &me && *level >= Level::Warn);
-        assert!(
-            !warned,
-            "NUL-producing keys must not log at warn level or above"
-        );
+    #[test]
+    fn corrupt_buffer_still_warns() {
+        capture_thread_logs();
+
+        // An interior NUL past the first byte cannot come from well-formed
+        // XLookupString output, so it must stay loud.
+        let mut buffer = [0; 24];
+        buffer[0] = b'a';
+        let mut raw = default_raw_input_event();
+        raw.buffer = buffer;
+        raw.buffer_len = 2;
+        raw.key_sym = 0x41;
+        raw.key_code = 38;
+
+        let result: Option<InputEvent> =
+            convert_raw_input_event_to_input_event(raw, &HashMap::new(), 0);
+        assert!(result.unwrap().into_keyboard().unwrap().value.is_none());
+        assert!(thread_logged_at_or_above(Level::Warn));
     }
 
     #[test]

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -318,7 +318,7 @@ fn convert_raw_input_event_to_input_event(
                         }
                     }
                     Err(err) => {
-                        warn!("Received malformed char: {}", err);
+                        trace!("Received malformed char: {}", err);
                         None
                     }
                 }
@@ -537,6 +537,64 @@ mod tests {
         let result: Option<InputEvent> =
             convert_raw_input_event_to_input_event(raw, &HashMap::new(), 0);
         assert!(result.unwrap().into_keyboard().unwrap().value.is_none());
+    }
+
+    #[test]
+    fn nul_key_does_not_warn() {
+        use log::{Level, LevelFilter, Log, Metadata, Record};
+        use std::sync::{Mutex, OnceLock};
+
+        struct Capture {
+            records: Mutex<Vec<(std::thread::ThreadId, Level)>>,
+        }
+        impl Log for Capture {
+            fn enabled(&self, _: &Metadata) -> bool {
+                true
+            }
+            fn log(&self, record: &Record) {
+                self.records.lock().unwrap().push((
+                    std::thread::current().id(),
+                    record.level(),
+                ));
+            }
+            fn flush(&self) {}
+        }
+
+        static LOGGER: OnceLock<Capture> = OnceLock::new();
+        let logger = LOGGER.get_or_init(|| Capture {
+            records: Mutex::new(Vec::new()),
+        });
+        // A logger can only be set once per test process; reuse it if so.
+        let _ = log::set_logger(logger);
+        log::set_max_level(LevelFilter::Trace);
+
+        logger.records.lock().unwrap().clear();
+
+        // NUL-producing key (e.g. Ctrl-Space): XLookupString returns a
+        // single NUL byte. This is legitimate input, not corruption.
+        let mut raw = default_raw_input_event();
+        raw.buffer = [0; 24];
+        raw.buffer_len = 1;
+        raw.key_sym = 0x20;
+        raw.key_code = 65;
+
+        let result: Option<InputEvent> =
+            convert_raw_input_event_to_input_event(raw, &HashMap::new(), 0);
+        assert!(result.unwrap().into_keyboard().unwrap().value.is_none());
+
+        // Other tests log on their own threads; only records from this
+        // thread belong to the conversion above.
+        let me = std::thread::current().id();
+        let warned = logger
+            .records
+            .lock()
+            .unwrap()
+            .iter()
+            .any(|(thread, level)| thread == &me && *level >= Level::Warn);
+        assert!(
+            !warned,
+            "NUL-producing keys must not log at warn level or above"
+        );
     }
 
     #[test]

--- a/espanso-detect/src/x11/mod.rs
+++ b/espanso-detect/src/x11/mod.rs
@@ -557,7 +557,9 @@ mod tests {
     }
 
     impl Log for Capture {
-        fn enabled(&self, _: &Metadata) -> bool { true }
+        fn enabled(&self, _: &Metadata) -> bool {
+            true
+        }
 
         fn log(&self, record: &Record) {
             let thread = std::thread::current().id();


### PR DESCRIPTION
### Issue for this PR

Closes #2799

### Type of change

- [x] Bug fix
- [ ] New feature
- [ ] Refactor / code improvement
- [ ] Documentation

### What does this PR do?

Pressing a NUL-producing key (e.g. Ctrl-Space) on the X11 backend logged a spurious `Received malformed char: data provided contains an interior nul byte at byte position 0` warning per press/release. Root cause (fully traced in #2799): `native.cpp` zero-initializes the event buffer and caps `XLookupString` at 23 of 24 bytes, so the terminal NUL is structurally guaranteed and `CStr::from_bytes_with_nul` can only fail via `InteriorNul` — i.e. only when X11 itself returned a NUL byte, which is legitimate input (Control-modified keys map to ASCII control characters per the XLookupString contract).

- Discriminates in the `from_bytes_with_nul` `Err` arm: `trace!` for the lone-NUL shape (`buffer_len == 1`, the only shape legitimate `XLookupString` output can take here), `warn!` otherwise — multi-byte interiors cannot come from well-formed detector output, so they stay loud. The adjacent UTF-8 failure arm (`char conversion error`) still warns unconditionally.
- Adds two regression tests sharing a thread-filtered capturing logger: `nul_key_does_not_warn` (synthetic NUL-key event must resolve to `value: None` with no warn-or-above record; fails on the old `warn!`) and `corrupt_buffer_still_warns` (`buffer[0] = b'a'`, `buffer_len = 2` must still warn, pinning the boundary from the loud side).

### How did you verify your code works?

- Regression tests constructed as genuine red-green pairs: `nul_key_does_not_warn` fails on the old blanket `warn!` and passes with the discriminator; `corrupt_buffer_still_warns` fails on blanket `trace!` (over-silencing) and passes with it.
- Empirical confirmation of the trigger on espanso 2.4.1 / X11 quoted in #2799: a timestamp-bracketed Ctrl-Space tap produced exactly the predicted warn pair.
- [ ] I have tested my changes locally — **not run**: this sandbox has no Rust toolchain (rustup shims with no installed toolchain, installs blocked by read-only FS), so `cargo test`/`clippy`/`fmt` could not run here. Requesting CI as the executing verifier; the change is a log-level branch plus two self-contained tests, and all imports used (`trace`, `log::{Level, LevelFilter, Log, Metadata, Record}`, `std::sync::{Mutex, OnceLock}`) were verified present/compatible against master.

### Checklist

- [ ] I have tested my changes locally (see above — blocked, CI requested)
- [x] I have not included unrelated changes in this PR